### PR TITLE
fix: handle missing /boot on WSL for Cloud Hypervisor guest kernel

### DIFF
--- a/bash/setup_ubuntu_arm.sh
+++ b/bash/setup_ubuntu_arm.sh
@@ -154,6 +154,10 @@ verify_archive_sha256_from_checksums() {
     fi
 }
 
+is_wsl() {
+    grep -qi microsoft /proc/version 2>/dev/null
+}
+
 resolve_boot_asset() {
     local preferred_path="$1"
     local fallback_pattern="$2"
@@ -167,15 +171,17 @@ resolve_boot_asset() {
         fi
     fi
 
-    resolved_path="$(
-        find /boot -maxdepth 1 -type f -name "$fallback_pattern" -printf '%T@ %p\n' \
-            | sort -nr \
-            | head -n1 \
-            | cut -d' ' -f2-
-    )"
-    if [ -n "$resolved_path" ] && [ -f "$resolved_path" ]; then
-        printf '%s\n' "$resolved_path"
-        return 0
+    if [ -d /boot ]; then
+        resolved_path="$(
+            find /boot -maxdepth 1 -type f -name "$fallback_pattern" -printf '%T@ %p\n' \
+                | sort -nr \
+                | head -n1 \
+                | cut -d' ' -f2-
+        )"
+        if [ -n "$resolved_path" ] && [ -f "$resolved_path" ]; then
+            printf '%s\n' "$resolved_path"
+            return 0
+        fi
     fi
 
     return 1
@@ -294,8 +300,17 @@ provision_cloud_hypervisor_assets() {
         fail "Unable to download Cloud Hypervisor ${CH_VERSION} release asset for arm64."
     fi
 
-    kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" \
-        || fail "Unable to locate kernel in /boot (checked /boot/vmlinuz and vmlinuz-*)."
+    kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" || {
+        if is_wsl; then
+            echo "WSL detected: no kernel in /boot. Installing linux-image-virtual for CH guest kernel..."
+            apt-get install -y --no-install-recommends linux-image-virtual > /dev/null 2>&1 \
+                || fail "Failed to install linux-image-virtual. Install a kernel package manually: apt-get install linux-image-virtual"
+            kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" \
+                || fail "Still unable to locate kernel in /boot after installing linux-image-virtual."
+        else
+            fail "Unable to locate kernel in /boot (checked /boot/vmlinuz and vmlinuz-*)."
+        fi
+    }
 
     cp -f "$kernel_source" "$ch_kernel_target"
     chmod 0644 "$ch_kernel_target"

--- a/bash/setup_ubuntu_x86.sh
+++ b/bash/setup_ubuntu_x86.sh
@@ -150,6 +150,10 @@ verify_archive_sha256_from_checksums() {
     fi
 }
 
+is_wsl() {
+    grep -qi microsoft /proc/version 2>/dev/null
+}
+
 resolve_boot_asset() {
     local preferred_path="$1"
     local fallback_pattern="$2"
@@ -163,15 +167,17 @@ resolve_boot_asset() {
         fi
     fi
 
-    resolved_path="$(
-        find /boot -maxdepth 1 -type f -name "$fallback_pattern" -printf '%T@ %p\n' \
-            | sort -nr \
-            | head -n1 \
-            | cut -d' ' -f2-
-    )"
-    if [ -n "$resolved_path" ] && [ -f "$resolved_path" ]; then
-        printf '%s\n' "$resolved_path"
-        return 0
+    if [ -d /boot ]; then
+        resolved_path="$(
+            find /boot -maxdepth 1 -type f -name "$fallback_pattern" -printf '%T@ %p\n' \
+                | sort -nr \
+                | head -n1 \
+                | cut -d' ' -f2-
+        )"
+        if [ -n "$resolved_path" ] && [ -f "$resolved_path" ]; then
+            printf '%s\n' "$resolved_path"
+            return 0
+        fi
     fi
 
     return 1
@@ -290,8 +296,17 @@ provision_cloud_hypervisor_assets() {
         fail "Unable to download Cloud Hypervisor ${CH_VERSION} release asset for x86_64."
     fi
 
-    kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" \
-        || fail "Unable to locate kernel in /boot (checked /boot/vmlinuz and vmlinuz-*)."
+    kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" || {
+        if is_wsl; then
+            echo "WSL detected: no kernel in /boot. Installing linux-image-virtual for CH guest kernel..."
+            apt-get install -y --no-install-recommends linux-image-virtual > /dev/null 2>&1 \
+                || fail "Failed to install linux-image-virtual. Install a kernel package manually: apt-get install linux-image-virtual"
+            kernel_source="$(resolve_boot_asset "/boot/vmlinuz" "vmlinuz-*")" \
+                || fail "Still unable to locate kernel in /boot after installing linux-image-virtual."
+        else
+            fail "Unable to locate kernel in /boot (checked /boot/vmlinuz and vmlinuz-*)."
+        fi
+    }
 
     cp -f "$kernel_source" "$ch_kernel_target"
     chmod 0644 "$ch_kernel_target"


### PR DESCRIPTION
## Summary

- WSL doesn't have `/boot` or any `vmlinuz-*`, causing `install.sh` to fail with `find: '/boot': No such file or directory`
- Adds WSL detection (`/proc/version` check) and auto-installs `linux-image-virtual` as a lightweight guest kernel fallback
- Guards `find /boot` with `[ -d /boot ]` to avoid hard errors on systems without `/boot`
- Applied to both `setup_ubuntu_x86.sh` and `setup_ubuntu_arm.sh`

## Context

Reported by @jossemii — the install script assumes the host has a kernel in `/boot` and copies it for Cloud Hypervisor guest VMs. On native Ubuntu this works because the host kernel is there. On WSL, the kernel is managed by Windows and `/boot` doesn't exist.

`linux-image-virtual` is the right choice because it's Ubuntu's minimal kernel with virtio drivers — exactly what Cloud Hypervisor needs for guest VMs.

## Test plan

- [ ] Run `install.sh` on native Ubuntu (x86) — should work as before (no behavior change)
- [ ] Run `install.sh` on WSL2 Ubuntu (x86) — should detect WSL, install `linux-image-virtual`, and continue
- [ ] Verify Cloud Hypervisor can boot a guest VM with the installed kernel on WSL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)