### PR TITLE
fix: support reputation proof data inputs with AppKit fallback

### DIFF
--- a/src/reputation_system/contracts/ergo/transaction.py
+++ b/src/reputation_system/contracts/ergo/transaction.py
@@ -73,6 +73,60 @@ def _get_type_nft_boxes(node_url: str, type_nft_ids: List[str]) -> list:
     return data_inputs
 
 
+def _explorer_box_to_input_box(box_payload: dict):
+    jpype = require_java_module("jpype", feature="Ergo reputation")
+    org = jpype.JPackage("org")
+
+    output_info_cls = org.ergoplatform.explorer.client.model.OutputInfo
+    input_box_impl_cls = org.ergoplatform.appkit.impl.InputBoxImpl
+    gson = org.ergoplatform.restapi.client.JSON.createGson().create()
+    output_info = gson.fromJson(json.dumps(box_payload), output_info_cls)
+    return input_box_impl_cls(output_info)
+
+
+def _attach_data_inputs(tx_builder, data_inputs) -> None:
+    for method_name in ("withDataInputs", "addDataInputs"):
+        method = getattr(tx_builder, method_name, None)
+        if not method:
+            continue
+
+        call_attempts = [
+            lambda: method(data_inputs),
+            lambda: method(*data_inputs),
+        ]
+        for attempt in call_attempts:
+            try:
+                attempt()
+                return
+            except TypeError:
+                continue
+
+    raise RuntimeError("AppKit transaction builder does not expose withDataInputs/addDataInputs")
+
+
+def _build_unsigned_transaction(ergo, input_boxes, outputs, fee: int, sender_address, data_inputs: Optional[list] = None):
+    tx_kwargs = dict(
+        input_box=input_boxes,
+        outBox=outputs,
+        fee=fee / 10**9,
+        sender_address=sender_address,
+    )
+
+    if not data_inputs:
+        return ergo.buildUnsignedTransaction(**tx_kwargs)
+
+    # Prefer the higher-level ergpy API when available.
+    for kwarg in ("dataInput", "dataInputs"):
+        try:
+            return ergo.buildUnsignedTransaction(**tx_kwargs, **{kwarg: data_inputs})
+        except TypeError:
+            pass
+
+    tx_builder = ergo._ctx.newTxBuilder()         .boxesToSpend(input_boxes)         .outputs(outputs)         .fee(fee)         .sendChangeTo(sender_address.asP2PK())
+    _attach_data_inputs(tx_builder, data_inputs)
+    return tx_builder.build()
+
+
 def __build_proof_box(
     ergo,
     proof_id: str,
@@ -216,26 +270,19 @@ def __create_reputation_proof_tx(node_url: str, wallet_mnemonic: str, proof_id: 
     outputs.extend(output_boxes)
 
     # Resolve and attach DPG type boxes as dataInputs.
-    data_inputs = _get_type_nft_boxes(
+    data_input_payloads = _get_type_nft_boxes(
         node_url=node_url,
         type_nft_ids=[CELAUT_NODE_TYPE_NFT_ID],
     )
-
-    tx_kwargs = dict(
-        input_box=java_input_boxes,
-        outBox=outputs,
-        fee=fee / 10**9,
+    java_data_inputs = [_explorer_box_to_input_box(box_payload) for box_payload in data_input_payloads]
+    unsigned_tx = _build_unsigned_transaction(
+        ergo=ergo,
+        input_boxes=java_input_boxes,
+        outputs=outputs,
+        fee=fee,
         sender_address=sender_address,
+        data_inputs=java_data_inputs,
     )
-
-    # API compatibility across ergpy/appkit versions.
-    try:
-        unsigned_tx = ergo.buildUnsignedTransaction(dataInput=data_inputs, **tx_kwargs)
-    except TypeError:
-        try:
-            unsigned_tx = ergo.buildUnsignedTransaction(dataInputs=data_inputs, **tx_kwargs)
-        except TypeError:
-            raise RuntimeError("AppKit does not expose dataInput/dataInputs argument; cannot satisfy Type NFT dataInputs requirement")
 
     mnemonic = ergo.getMnemonic(wallet_mnemonic=wallet_mnemonic, mnemonic_password=None)
     signed_tx = ergo.signTransaction(unsigned_tx, mnemonic[0], prover_index=0)

--- a/tests/test_reputation_data_inputs_compat.py
+++ b/tests/test_reputation_data_inputs_compat.py
@@ -1,0 +1,164 @@
+import sys
+import types
+import unittest
+from unittest import mock
+
+if "mnemonic" not in sys.modules:
+    mnemonic_module = types.ModuleType("mnemonic")
+
+    class _Mnemonic:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def generate(self, strength=128):
+            return "test mnemonic"
+
+    mnemonic_module.Mnemonic = _Mnemonic
+    sys.modules["mnemonic"] = mnemonic_module
+
+from src.reputation_system.contracts.ergo import transaction
+
+
+class _FakeSenderAddress:
+    def asP2PK(self):
+        return "sender-p2pk"
+
+
+class _FakeBuilder:
+    def __init__(self, accept_list=True, accept_add_list=True):
+        self.accept_list = accept_list
+        self.accept_add_list = accept_add_list
+        self.calls = []
+
+    def boxesToSpend(self, boxes):
+        self.calls.append(("boxesToSpend", boxes))
+        return self
+
+    def outputs(self, outputs):
+        self.calls.append(("outputs", outputs))
+        return self
+
+    def fee(self, fee):
+        self.calls.append(("fee", fee))
+        return self
+
+    def sendChangeTo(self, address):
+        self.calls.append(("sendChangeTo", address))
+        return self
+
+    def withDataInputs(self, *args):
+        if len(args) == 1 and isinstance(args[0], list) and self.accept_list:
+            self.calls.append(("withDataInputs", args[0]))
+            return self
+        raise TypeError("list form unsupported")
+
+    def addDataInputs(self, *args):
+        if len(args) == 1 and isinstance(args[0], list) and not self.accept_add_list:
+            raise TypeError("addDataInputs list form unsupported")
+        self.calls.append(("addDataInputs", list(args)))
+        return self
+
+    def build(self):
+        self.calls.append(("build", None))
+        return "built-directly"
+
+
+class _FakeCtx:
+    def __init__(self, builder):
+        self.builder = builder
+
+    def newTxBuilder(self):
+        return self.builder
+
+
+class _FakeErgo:
+    def __init__(self, error_on_kwargs=("dataInput", "dataInputs"), builder=None):
+        self.error_on_kwargs = set(error_on_kwargs)
+        self.builder = builder or _FakeBuilder()
+        self._ctx = _FakeCtx(self.builder)
+        self.calls = []
+
+    def buildUnsignedTransaction(self, **kwargs):
+        self.calls.append(kwargs)
+        forbidden = self.error_on_kwargs.intersection(kwargs)
+        if forbidden:
+            raise TypeError(f"unsupported {sorted(forbidden)[0]}")
+        return "built-wrapper"
+
+
+class ReputationDataInputsCompatTests(unittest.TestCase):
+    def test_build_unsigned_transaction_uses_wrapper_when_supported(self):
+        ergo = _FakeErgo(error_on_kwargs=())
+
+        result = transaction._build_unsigned_transaction(
+            ergo=ergo,
+            input_boxes=["in"],
+            outputs=["out"],
+            fee=1_000_000,
+            sender_address=_FakeSenderAddress(),
+            data_inputs=["data-box"],
+        )
+
+        self.assertEqual(result, "built-wrapper")
+        self.assertIn("dataInput", ergo.calls[0])
+
+    def test_build_unsigned_transaction_falls_back_to_direct_builder(self):
+        builder = _FakeBuilder()
+        ergo = _FakeErgo(builder=builder)
+
+        result = transaction._build_unsigned_transaction(
+            ergo=ergo,
+            input_boxes=["in"],
+            outputs=["out"],
+            fee=1_000_000,
+            sender_address=_FakeSenderAddress(),
+            data_inputs=["data-box"],
+        )
+
+        self.assertEqual(result, "built-directly")
+        self.assertEqual(ergo.calls[0]["fee"], 0.001)
+        self.assertEqual(builder.calls[-2], ("withDataInputs", ["data-box"]))
+
+    def test_attach_data_inputs_tries_varargs_compatibility(self):
+        builder = _FakeBuilder(accept_list=False, accept_add_list=False)
+
+        transaction._attach_data_inputs(builder, ["a", "b"])
+
+        self.assertIn(("addDataInputs", ["a", "b"]), builder.calls)
+
+    def test_explorer_box_to_input_box_uses_output_info_conversion(self):
+        fake_output_info_cls = object()
+        fake_input_box_impl = mock.Mock(return_value="input-box")
+        fake_gson = mock.Mock()
+        fake_gson.fromJson.return_value = "output-info"
+        fake_json = mock.Mock()
+        fake_json.createGson.return_value.create.return_value = fake_gson
+        fake_org = types.SimpleNamespace(
+            ergoplatform=types.SimpleNamespace(
+                explorer=types.SimpleNamespace(
+                    client=types.SimpleNamespace(
+                        model=types.SimpleNamespace(OutputInfo=fake_output_info_cls)
+                    )
+                ),
+                appkit=types.SimpleNamespace(
+                    impl=types.SimpleNamespace(InputBoxImpl=fake_input_box_impl)
+                ),
+                restapi=types.SimpleNamespace(
+                    client=types.SimpleNamespace(JSON=fake_json)
+                ),
+            )
+        )
+        fake_jpype = mock.Mock()
+        fake_jpype.JPackage.return_value = fake_org
+
+        with mock.patch.object(transaction, "require_java_module", return_value=fake_jpype):
+            result = transaction._explorer_box_to_input_box({"boxId": "abc"})
+
+        self.assertEqual(result, "input-box")
+        fake_gson.fromJson.assert_called_once()
+        self.assertIs(fake_gson.fromJson.call_args[0][1], fake_output_info_cls)
+        fake_input_box_impl.assert_called_once_with("output-info")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert explorer Type NFT box payloads into AppKit `InputBoxImpl` instances before tx build
- keep using `ergpy.buildUnsignedTransaction(...)` when it already supports `dataInput`/`dataInputs`
- fall back to the underlying AppKit transaction builder and attach data inputs via `withDataInputs`/`addDataInputs` when the ergpy wrapper does not expose those kwargs
- add targeted compatibility tests for the fallback path and explorer-box conversion

## Validation
- `python3 -m unittest tests.test_reputation_data_inputs_compat tests.test_ergo_token_import_compat tests.test_java_dependency_lazy_imports`
- `python3 -m py_compile src/reputation_system/contracts/ergo/transaction.py tests/test_reputation_data_inputs_compat.py`

## Notes
- This is a minimal compatibility fix for issue #80 inside the current AppKit/JPype path.
- It does not attempt the larger sigma-rust migration mentioned in the issue discussion.
