### PR TITLE
Clarify export arg (<path> → <dir>) and document KyA-bypass marker file

### DIFF
--- a/docs/QUICK_GUIDE.md
+++ b/docs/QUICK_GUIDE.md
@@ -23,7 +23,7 @@ Remote run:
    nodo execute --remote <service>
 
 Export package:
-   nodo export <service> <path>
+   nodo export <service> <dir>
 
 Raw .celaut:
-   nodo export <service> <path> --raw
+   nodo export <service> <dir> --raw

--- a/docs/QUICK_GUIDE.md
+++ b/docs/QUICK_GUIDE.md
@@ -22,8 +22,8 @@ EXTRAS
 Remote run:
    nodo execute --remote <service>
 
-Export package:
+Export package (importable .celaut.bee — share this, feed it to `nodo import`):
    nodo export <service> <dir>
 
-Raw .celaut:
+Raw .celaut (verify hash only — NOT importable):
    nodo export <service> <dir> --raw

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -107,10 +107,13 @@ These are the most commonly used commands for daily tasks:
   **Example:**  
   `nodo logs`
 
-- **export `<service> <dir>`**  
-  Exports a service into the specified directory.  
+- **export `<service> <dir> [--raw]`**  
+  Exports a service into the specified directory. Two modes:
+  - **`nodo export <service> <dir>`** (default) → writes `<service>.celaut.bee`, a beerpc-framed package. This is the **importable / transmittable** artifact — share it and feed it to `nodo import`.
+  - **`nodo export <service> <dir> --raw`** → writes a raw `<service>.celaut`. This is for **manual hash verification only** and is **NOT importable** — running `nodo import` on it fails with `Invalid file format: Incomplete message data`.  
   **Example:**  
-  `nodo export MyService /export/dir`
+  `nodo export MyService /export/dir`  
+  `nodo export MyService /export/dir --raw`  *(verify-only, not importable)*
 
 - **import `<path>`**  
   Imports a service from the specified path.  

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,6 +4,29 @@ This guide will help you understand and use the available commands in **Nodo**, 
 
 ---
 
+## Non-interactive use (automation / agents) ⚙️
+
+The first time you run Nodo it shows the **Know Your Assumptions (KyA)** document and waits for an interactive `yes/no` acceptance before any command runs. In headless or automated environments (CI, agents, scripts) there is no TTY to answer that prompt.
+
+You can **pre-accept the KyA and skip the gate** by creating an empty marker file at:
+
+```
+<MAIN_DIR>/storage/.acceptedkya
+```
+
+`MAIN_DIR` is the Nodo main directory configured in `config.yaml` (`main.MAIN_DIR`, default `/nodo`), so by default the marker is:
+
+```bash
+mkdir -p /nodo/storage
+touch /nodo/storage/.acceptedkya
+```
+
+When this file exists, Nodo treats the KyA as already accepted and starts without prompting. This is the same marker the interactive accept flow writes once you answer `yes`.
+
+> ⚠️ Creating this file means you accept the Know Your Assumptions ([`docs/KyA.md`](KyA.md)) without reading the interactive prompt. Only do this in environments you control.
+
+---
+
 ## Basic Commands
 
 These are the most commonly used commands for daily tasks:
@@ -84,10 +107,10 @@ These are the most commonly used commands for daily tasks:
   **Example:**  
   `nodo logs`
 
-- **export `<service> <path>`**  
-  Exports a service to a specified path.  
+- **export `<service> <dir>`**  
+  Exports a service into the specified directory.  
   **Example:**  
-  `nodo export MyService /export/path`
+  `nodo export MyService /export/dir`
 
 - **import `<path>`**  
   Imports a service from the specified path.  

--- a/nodo.py
+++ b/nodo.py
@@ -267,7 +267,7 @@ if __name__ == '__main__':
 
             case "export":
                 if len(sys.argv) < 4:
-                    print("Missing export path. Usage: nodo export <service> <path> [--raw]")
+                    print("Missing export dir. Usage: nodo export <service> <dir> [--raw]")
                     os._exit(1)
 
                 if len(sys.argv) > 4 and sys.argv[4] == "--raw":


### PR DESCRIPTION
This PR makes two small, behavior-preserving documentation/clarity changes Josemi requested.

## 1. Rename the `export` positional arg `<path>` → `<dir>`

The `nodo export` command writes the exported service into a **directory**, but the CLI usage string and docs called the argument `<path>`, which misleads users into thinking a file path is expected. Renamed it to `<dir>` for clarity. Behavior is unchanged.

- `nodo.py` — export usage/error string: `nodo export <service> <path> [--raw]` → `nodo export <service> <dir> [--raw]`
- `docs/USAGE.md` — export entry now reads `export <service> <dir>` ("Exports a service into the specified directory.")
- `docs/QUICK_GUIDE.md` — both `nodo export <service> <path>` and `... --raw` lines now use `<dir>`

(`import <path>` is left as-is, since import does take a file path.)

## 2. Document the non-interactive KyA bypass marker file

Added a **"Non-interactive use (automation / agents)"** section to `docs/USAGE.md` explaining that the **Know Your Assumptions (KyA)** acceptance gate — which normally prompts for an interactive `yes/no` on first run — can be skipped in headless/automated environments by creating an empty marker file:

```
<MAIN_DIR>/storage/.acceptedkya
```

`MAIN_DIR` is the configured main directory (`main.MAIN_DIR` in `config.yaml`, default `/nodo`), so the default marker is `/nodo/storage/.acceptedkya`. This is the exact path/filename Nodo checks on startup (`nodo.py`) and the same marker the interactive accept flow writes (`bash/accept_kya.sh`) once you answer `yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
