### PR TITLE
Fix systemd service template substitution

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -307,6 +307,12 @@ create_service_file() {
     -e "s|{{PYTHON_RUNTIME_BIN_DIR}}|$escaped_python_runtime_bin_dir|g" \
     -e "s|{{PYTHON_VENV_BIN}}|$escaped_python_venv_bin|g" \
     "$TARGET_DIR/bash/nodo.service.template" > "$expected_file"
+  if grep -q '{{[A-Z_][A-Z_]*}}' "$expected_file"; then
+    printf "Error: Unresolved placeholders remain in generated service file:\n" >&2
+    grep -o '{{[A-Z_][A-Z_]*}}' "$expected_file" | sort -u >&2
+    rm -f "$expected_file"
+    exit 1
+  fi
 
   if [ -f "$SERVICE_FILE" ] && cmp -s "$SERVICE_FILE" "$expected_file"; then
     printf "Service file %s is already up to date.\n" "$SERVICE_FILE"

--- a/src/commands/doctor.py
+++ b/src/commands/doctor.py
@@ -159,6 +159,76 @@ def _resolve_config_paths(main_dir: str):
     }
 
 
+def _get_nested_config(raw, path: str, default):
+    value = raw
+    for key in path.split("."):
+        if not isinstance(value, dict) or key not in value:
+            return default
+        value = value[key]
+    return value
+
+
+def _expand_main_dir_placeholder(value, main_dir: str):
+    if not isinstance(value, str):
+        return value
+    return value.replace("${main.MAIN_DIR}", main_dir)
+
+
+def _render_service_template(template_content: str, main_dir: str) -> str:
+    """Render nodo.service.template using the same config keys as install.sh."""
+    import yaml
+
+    config_path = os.path.join(main_dir, "config.yaml")
+    raw = {}
+    if os.path.isfile(config_path):
+        with open(config_path, "r") as f:
+            raw = yaml.safe_load(f) or {}
+
+    java_home = _expand_main_dir_placeholder(
+        _get_nested_config(
+            raw,
+            "dependencies.java.JAVA_HOME",
+            os.path.join(main_dir, "runtime", "java", "current"),
+        ),
+        main_dir,
+    )
+    python_runtime_bin = _expand_main_dir_placeholder(
+        _get_nested_config(
+            raw,
+            "dependencies.python.RUNTIME_BIN",
+            os.path.join(main_dir, "runtime", "python", "current", "bin", "python3"),
+        ),
+        main_dir,
+    )
+    python_venv_bin = _expand_main_dir_placeholder(
+        _get_nested_config(
+            raw,
+            "dependencies.python.VENV_BIN",
+            os.path.join(main_dir, "venv", "bin", "python"),
+        ),
+        main_dir,
+    )
+
+    replacements = {
+        "{{MAIN_DIR}}": main_dir,
+        "{{JAVA_HOME}}": java_home,
+        "{{PYTHON_RUNTIME_BIN_DIR}}": os.path.dirname(python_runtime_bin),
+        "{{PYTHON_VENV_BIN}}": python_venv_bin,
+    }
+
+    rendered = template_content
+    for placeholder, value in replacements.items():
+        rendered = rendered.replace(placeholder, value)
+
+    unresolved = sorted(set(re.findall(r"{{[A-Z_]+}}", rendered)))
+    if unresolved:
+        raise ValueError(
+            "Unresolved placeholders in nodo.service.template: " + ", ".join(unresolved)
+        )
+
+    return rendered
+
+
 def _get_host_arch_tag() -> str:
     machine = platform.machine().lower()
     if machine in ("x86_64", "amd64"):
@@ -512,7 +582,11 @@ def doctor_command(main_dir):
         return
 
     with open(template_file, "r") as f:
-        expected_content = f.read().replace("{{MAIN_DIR}}", main_dir)
+        try:
+            expected_content = _render_service_template(f.read(), main_dir)
+        except ValueError as e:
+            print(f"Error: {e}", flush=True)
+            return
     expected_service_user = _parse_unit_user(expected_content)
 
     needs_fix = False

--- a/tests/test_doctor_service_template_render.py
+++ b/tests/test_doctor_service_template_render.py
@@ -1,0 +1,38 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.commands.doctor import _render_service_template
+
+
+class DoctorServiceTemplateRenderTests(unittest.TestCase):
+    def test_renders_all_systemd_template_runtime_placeholders(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            main_dir = Path(tmpdir)
+            (main_dir / "config.yaml").write_text(
+                """
+dependencies:
+  java:
+    JAVA_HOME: "${main.MAIN_DIR}/custom/java"
+  python:
+    RUNTIME_BIN: "${main.MAIN_DIR}/custom/python/bin/python3"
+    VENV_BIN: "${main.MAIN_DIR}/custom/venv/bin/python"
+""",
+                encoding="utf-8",
+            )
+
+            template = Path("bash/nodo.service.template").read_text(encoding="utf-8")
+            rendered = _render_service_template(template, str(main_dir))
+
+        self.assertNotIn("{{", rendered)
+        self.assertIn(f"Environment=JAVA_HOME={main_dir}/custom/java", rendered)
+        self.assertIn(f"{main_dir}/custom/python/bin", rendered)
+        self.assertIn(f"exec {main_dir}/custom/venv/bin/python {main_dir}/nodo.py serve", rendered)
+
+    def test_rejects_unresolved_systemd_template_placeholders(self):
+        with self.assertRaisesRegex(ValueError, "UNKNOWN_PLACEHOLDER"):
+            _render_service_template("ExecStart={{UNKNOWN_PLACEHOLDER}}\n", "/nodo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Render every placeholder in `bash/nodo.service.template` when `nodo doctor` builds the expected unit.
- Keep `install.sh` concrete-unit generation guarded so future unresolved `{{...}}` placeholders fail before writing `/etc/systemd/system/nodo.service`.
- Add coverage proving the doctor renderer emits a fully concrete systemd unit from configured runtime paths.

## Bug
The doctor path only replaced `{{MAIN_DIR}}`, leaving `{{JAVA_HOME}}`, `{{PYTHON_RUNTIME_BIN_DIR}}`, and `{{PYTHON_VENV_BIN}}` literal in its expected unit. On a real install that can produce `ExecStart={{PYTHON_VENV_BIN}} ...`, causing systemd to fail with exit 127 and crash-loop before the gateway starts. Because doctor compared against the same partially-rendered template, it could report the broken unit as OK and overwrite a manual fix back to placeholder form.

## Fix
`doctor_command()` now renders the service template with the same resolved values as the installer and refuses unresolved placeholders. The values are sourced from:
- `main_dir` for `{{MAIN_DIR}}` and `${main.MAIN_DIR}` interpolation
- `dependencies.java.JAVA_HOME` for `{{JAVA_HOME}}`
- `dependencies.python.RUNTIME_BIN`, with `dirname`, for `{{PYTHON_RUNTIME_BIN_DIR}}`
- `dependencies.python.VENV_BIN` for `{{PYTHON_VENV_BIN}}`

## Tests
- `python3 -m unittest tests.test_doctor_service_template_render tests.test_service_template_runtime_env`
- `bash -n install.sh`

Full `python3 -m unittest discover` is currently blocked by missing local optional dependencies: `bee_rpc`, `mnemonic`, and `psutil`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)