### PR TITLE
Fix CH initramfs modprobe path parse on Ubuntu 22.04 (trailing space)

### DIFF
--- a/bash/build_ch_initramfs.sh
+++ b/bash/build_ch_initramfs.sh
@@ -158,6 +158,10 @@ install_virtio_modules() {
             case "$dep_line" in
                 insmod\ *)
                     source_path="${dep_line#insmod }"
+                    # modprobe --show-depends on Ubuntu 22.04 emits a trailing space after
+                    # the .ko path; strip trailing whitespace so the [ -f ] test sees the
+                    # real file instead of failing on "<path> " with a phantom trailing space.
+                    source_path="${source_path%"${source_path##*[![:space:]]}"}"
                     [ -f "$source_path" ] || fail "modprobe returned missing module path: $source_path"
                     initramfs_path="$(copy_kernel_module "$source_path")"
                     if ! grep -Fxq "$initramfs_path" "$module_list"; then

--- a/tests/test_ch_initramfs_builder.py
+++ b/tests/test_ch_initramfs_builder.py
@@ -16,6 +16,20 @@ class CloudHypervisorInitramfsBuilderTests(unittest.TestCase):
             content.index("while [ \"$i\" -lt \"$WAIT_SECONDS\" ]"),
         )
 
+    def test_builder_strips_trailing_whitespace_from_module_path(self):
+        # modprobe --show-depends on Ubuntu 22.04 appends a trailing space after the
+        # .ko path; the builder must trim it before the [ -f ] existence check, or the
+        # install aborts with "modprobe returned missing module path" on a file that exists.
+        content = Path("bash/build_ch_initramfs.sh").read_text(encoding="utf-8")
+        self.assertIn(
+            'source_path="${source_path%"${source_path##*[![:space:]]}"}"',
+            content,
+        )
+        self.assertLess(
+            content.index('source_path="${source_path%'),
+            content.index('|| fail "modprobe returned missing module path'),
+        )
+
     def test_setup_scripts_pass_guest_kernel_path_to_initramfs_builder(self):
         for script in ("bash/setup_ubuntu_x86.sh", "bash/setup_ubuntu_arm.sh"):
             with self.subTest(script=script):


### PR DESCRIPTION
## Summary
Strip trailing whitespace from the kernel-module path that `build_ch_initramfs.sh`
parses out of `modprobe --show-depends`, so the `[ -f ]` existence check looks at the
real `.ko` file instead of `"<path> "` with a phantom trailing space.

## Bug
The virtio-module discovery added for the Cloud Hypervisor initramfs does:

```sh
source_path="${dep_line#insmod }"
[ -f "$source_path" ] || fail "modprobe returned missing module path: $source_path"
```

On Ubuntu 22.04, `modprobe --show-depends` emits a **trailing space** after the `.ko`
path. `${dep_line#insmod }` only strips the leading `insmod `, so `source_path` keeps the
trailing space and `[ -f "$source_path" ]` tests a path that does not exist. Install aborts:

```text
Error: modprobe returned missing module path: /lib/modules/5.15.0-174-generic/kernel/drivers/block/virtio_blk.ko
```

…even though `virtio_blk.ko` is installed (`linux-modules` + `linux-modules-extra` for the
guest kernel are present).

## Repro environment
Alienware WSL2 node, Ubuntu 22.04, copied guest kernel `5.15.0-174-generic`. The virtio
`.ko` files were installed; install still aborted at the CH initramfs step before Python /
Docker / `nodo.service` were set up, so it blocks a clean full install.

## Fix
Trim trailing whitespace from `source_path` before the existence check:

```sh
source_path="${dep_line#insmod }"
source_path="${source_path%"${source_path##*[![:space:]]}"}"
```

Adds a focused assertion to `tests/test_ch_initramfs_builder.py`.

## Tests
- `python3 -m unittest tests.test_ch_initramfs_builder` (3 tests, OK)
- `bash -n bash/build_ch_initramfs.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
