### PR TITLE
Read receiver wallet from documented AUXILIARY_MNEMONIC config key

### DIFF
--- a/src/payment_system/contracts/ergo/interface.py
+++ b/src/payment_system/contracts/ergo/interface.py
@@ -35,7 +35,13 @@ COLD_WALLET = lambda: env_manager.get('PAYMENTS_RECIVER_WALLET')
 ERGO_DONATION_WALLET = lambda: env_manager.get('ledgers.ergo.DONATION_WALLET')
 DONATION_PERCENTAGE = lambda: clamp(float(env_manager.get('ledgers.ergo.DONATION_PERCENTAGE')), 1.0, 0.0)  # type: ignore
 HOT_LIMITS = int(env_manager.get("ledgers.ergo.HOT_WALLET_LIMITS"))  # type: ignore
-AUXILIAR_MNEMONIC = env_manager.get("ledgers.ergo.AUXILIAR_MNEMONIC")  # Receiver wallet
+# Receiver wallet. The documented/config key is AUXILIARY_MNEMONIC (see config.example.yaml
+# and the auto-generation in src/utils/config.py); fall back to the legacy AUXILIAR_MNEMONIC
+# spelling for back-compat with any node that already set the misspelled key.
+AUXILIAR_MNEMONIC = (
+    env_manager.get("ledgers.ergo.AUXILIARY_MNEMONIC")
+    or env_manager.get("ledgers.ergo.AUXILIAR_MNEMONIC")
+)
 WALLET_MNEMONIC = lambda: env_manager.get('ledgers.ergo.WALLET_MNEMONIC')  # Sender wallet
 GAS_PER_ERG_L = lambda: int(env_manager.get("ledgers.ergo.GAS_PER_ERG"))
 WAIT_TX_TIME = 240  # 20 minutes (each 5 seconds)


### PR DESCRIPTION
## Summary
Read the Ergo receiver/intermediary wallet seed from the **documented** config key
`ledgers.ergo.AUXILIARY_MNEMONIC` (with a Y), with a back-compat fallback to the legacy
misspelled `AUXILIAR_MNEMONIC`.

## Bug
`src/payment_system/contracts/ergo/interface.py` read the receiver wallet from:

```python
AUXILIAR_MNEMONIC = env_manager.get("ledgers.ergo.AUXILIAR_MNEMONIC")  # no Y
```

But every other place spells the key **`AUXILIARY_MNEMONIC`** (with Y):

- `config.example.yaml` documents `ledgers.ergo.AUXILIARY_MNEMONIC: ""`
- `src/utils/config.py` auto-generation writes the generated mnemonic to
  `AUXILIARY_MNEMONIC` when the user sets it to `"auto"`

So a documented or auto-generated receiver seed was **never read** by the payment code —
`AUXILIAR_MNEMONIC` resolved to the default, silently misdirecting the
`AUXILIAR → MAIN` wallet sweep in the receiver path.

## Repro environment
Surfaced wiring an Ergo hot/receiver wallet on an Alienware WSL2 nodo install: the
receiver seed set under the documented `AUXILIARY_MNEMONIC` key was ignored until the
no-Y key was also set as a workaround.

## Fix
```python
AUXILIAR_MNEMONIC = (
    env_manager.get("ledgers.ergo.AUXILIARY_MNEMONIC")
    or env_manager.get("ledgers.ergo.AUXILIAR_MNEMONIC")
)
```

Reading `AUXILIARY_MNEMONIC` first aligns the code with the docs and the `config.py`
auto-generation; the fallback keeps any node that already set the misspelled key working.
`interface.py:38` is the only site that reads this config key — the remaining
`AUXILIAR_MNEMONIC` references (and in `src/commands/tx_history.py`) are uses of this local
symbol, so the diff stays minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
