### PR TITLE
Allow wildcard network tag egress for sealed CH microVMs

### DIFF
--- a/src/manager/networks.py
+++ b/src/manager/networks.py
@@ -52,6 +52,10 @@ def resolve_ergo_network() -> List[celaut.Instance.Uri]:
         return []
 
 def resolve_network(network: celaut.Service.Network) -> List[celaut.Instance]:
+    # Wildcard "*" (open-internet egress) and any unresolved tag resolve to no
+    # concrete peer instances; initialise uris so an unmatched loop cannot raise
+    # UnboundLocalError (it previously did for tag "*").
+    uris: List[celaut.Instance.Uri] = []
     for tag in network.tags:
         if "ergo" in tag:
             uris = resolve_ergo_network()
@@ -64,6 +68,11 @@ def resolve_network(network: celaut.Service.Network) -> List[celaut.Instance]:
         uris = resolve_domain(tag)
         if uris:
             break
+
+    if not uris:
+        # No concrete peer URIs (e.g. wildcard "*"): the tag is honoured at the
+        # firewall layer (allow-all egress); there is no peer instance to advertise.
+        return []
 
     client_protocol_stack = network.protocol_stack
     i_slot = 1  # Default slot id (because internal port usage is irrelevant here)

--- a/src/virtualizers/ch/execute.py
+++ b/src/virtualizers/ch/execute.py
@@ -29,6 +29,7 @@ from src.virtualizers.firewall import (
     allow_connection as vm_allow_connection,
     allow_connection_to_instance as vm_allow_connection_to_instance,
     block_all as vm_block_all,
+    allow_all_egress as vm_allow_all_egress,
     resolve_slot_transport_protocols,
 )
 
@@ -810,6 +811,17 @@ def _configure_guest_firewall_policy(
     log.LOGGER(
         f"[CH][{vmachine_id}] firewall allow DNS: {vm_ip} -> {NETWORK_GATEWAY_IP}:53/tcp,udp"
     )
+
+    # Network tag "*" => open-internet egress. Allow-all is inserted at the head
+    # of FORWARD so it takes precedence over the default-deny block_all rule.
+    if any(tag == "*" for net_res in network_resolution for tag in net_res.tags):
+        if not vm_allow_all_egress(vmachine_id=vmachine_id, source_ip=vm_ip):
+            raise CHExecuteError(
+                f"Failed to apply allow-all egress (network tag '*') for VM {vmachine_id} ({vm_ip})."
+            )
+        log.LOGGER(
+            f"[CH][{vmachine_id}] firewall allow-all egress (network tag '*')"
+        )
 
     for net_res in network_resolution:
         tag = net_res.tags[0] if net_res.tags else "<untagged>"

--- a/src/virtualizers/ch/firewall.py
+++ b/src/virtualizers/ch/firewall.py
@@ -224,3 +224,27 @@ def remove_rule(
     except Exception as e:
         logger(f"[CH][FW] Failed to remove rule for {vmachine_id}: {e}")
         return False
+
+def allow_all_egress(vmachine_id: str, source_ip: Optional[str] = None) -> bool:
+    """Allow ALL outbound traffic from the VM (used for network tag '*').
+
+    Inserted at the head of FORWARD so it short-circuits the block_all DROP rule.
+    Return traffic is covered by the global ESTABLISHED/RELATED accept rule.
+    """
+    try:
+        vm_ip = _resolve_vmachine_ip(vmachine_id=vmachine_id, source_ip=source_ip)
+        success, message = _execute_iptables([
+            "-I", "FORWARD",
+            "-s", vm_ip,
+            "-m", "comment",
+            "--comment", f"nodo;allow_all_egress;vm={vmachine_id}",
+            "-j", "ACCEPT",
+        ])
+        if success:
+            logger(f"[CH][FW] Allowed ALL egress for {vmachine_id} ({vm_ip}) [network tag '*']")
+        else:
+            logger(f"[CH][FW] Failed to allow all egress for {vmachine_id} ({vm_ip}): {message}")
+        return success
+    except Exception as e:
+        logger(f"[CH][FW] Failed to allow all egress for {vmachine_id}: {e}")
+        return False

--- a/src/virtualizers/docker/firewall.py
+++ b/src/virtualizers/docker/firewall.py
@@ -228,3 +228,21 @@ def list_rules(container_id: str) -> List[NetworkRule]:
     except Exception as e:
         logger(f"Failed to list rules: {e}")
         return []
+
+def allow_all_egress(container_id: str) -> bool:
+    """Allow ALL outbound traffic from a container (network tag '*')."""
+    try:
+        container_ip = __get_container_ip(container_id)
+        success, message = __execute_iptables([
+            '-I', 'FORWARD',
+            '-s', container_ip,
+            '-j', 'ACCEPT',
+        ])
+        if success:
+            logger(f"Allowed ALL egress for container {container_id} [network tag '*']")
+        else:
+            logger(f"Failed to allow all egress for container {container_id}: {message}")
+        return success
+    except Exception as e:
+        logger(f"Failed to allow all egress: {e}")
+        return False

--- a/src/virtualizers/firewall.py
+++ b/src/virtualizers/firewall.py
@@ -302,6 +302,21 @@ def block_all(vmachine_id: str, source_ip: Optional[str] = None) -> bool:
     raise ValueError(f"Unknown virtualizer for instance {vmachine_id}")
 
 
+def allow_all_egress(vmachine_id: str, source_ip: Optional[str] = None) -> bool:
+    virtualizer = _resolve_virtualizer(vmachine_id)
+    if virtualizer == "ch":
+        from src.virtualizers.ch.firewall import allow_all_egress as ch_allow_all_egress
+
+        return ch_allow_all_egress(vmachine_id=vmachine_id, source_ip=source_ip)
+
+    if virtualizer == "docker":
+        from src.virtualizers.docker.firewall import allow_all_egress as docker_allow_all_egress
+
+        return docker_allow_all_egress(container_id=vmachine_id)
+
+    raise ValueError(f"Unknown virtualizer for instance {vmachine_id}")
+
+
 def remove_rule(
     vmachine_id: str,
     ip: str,


### PR DESCRIPTION
## Problem

A service can declare unrestricted network access with a wildcard tag (`network: ["*"]`). Two issues prevented this from working with the Cloud Hypervisor (CH) microVM virtualizer:

1. **Crash on resolve.** `networks.resolve_network()` leaves its local `uris` unbound for any non-domain / non-ergo tag — the wildcard hits the `continue` branch on every iteration, so `uris` is never assigned → `UnboundLocalError` → `CHExecuteError` at launch.
2. **Default-deny firewall with no allow-all path.** The CH guest firewall `block_all`'s the VM and only permits `VM → gateway` + DNS, so even a service that explicitly requested open egress could never reach the internet (e.g. an in-guest `buildx` pulling base images).

## Fix

1. `networks.py` — initialize `uris = []` and `return []` when nothing resolves. A wildcard yields no concrete peer instance and must not crash.
2. Add `allow_all_egress()` to the **ch** and **docker** firewall backends — insert an `ACCEPT` for the VM source above the `block_all` DROP (return traffic is already covered by the global `ESTABLISHED/RELATED` accept).
3. Add a dispatcher in `virtualizers/firewall.py` and wire it into `ch/execute.py`'s guest firewall policy: when a service's resolved network tags contain `"*"`, open egress *after* the gateway + DNS rules.

5 files, +78 lines, no deletions.

## Verification

Runtime-verified inside a running sealed CH microVM:

```
$ iptables -S FORWARD
... -s <vm_ip> -j ACCEPT  /* nodo;allow_all_egress;vm=<id> */   # ahead of the default-deny drops
```

A sealed CH microVM running `dockerd` + `buildx` was then able to pull base images and complete a build — previously impossible under default-deny egress.
