### PR TITLE
Fix multi-source COPY path rewrite in zip_with_dockerfile packer

### DIFF
--- a/src/commands/packer/zip_with_dockerfile/prepare_directory.py
+++ b/src/commands/packer/zip_with_dockerfile/prepare_directory.py
@@ -22,8 +22,22 @@ def __dockerfile_copy_from(directory: str):
             for line in lines:
                 if line.strip().startswith("COPY "):
                     parts = line.split()
-                    if len(parts) > 1 and parts[1].startswith("."):
-                        parts[1] = "service" + parts[1][1:]
+                    # A COPY may have several context sources before the final
+                    # destination: `COPY src1 src2 ... dest`. The build context is
+                    # the .service/ dir (project files live under service/), so
+                    # EVERY context source that starts with "." must be re-prefixed
+                    # — not just the first one. `--from=<stage>` sources reference a
+                    # build stage rather than the context, so leave those untouched.
+                    flags = [p for p in parts[1:] if p.startswith("--")]
+                    if len(parts) >= 3 and not any(
+                        f.startswith("--from") for f in flags
+                    ):
+                        start = 1
+                        while start < len(parts) and parts[start].startswith("--"):
+                            start += 1
+                        for j in range(start, len(parts) - 1):  # sources, not dest
+                            if parts[j].startswith("."):
+                                parts[j] = "service" + parts[j][1:]
                         line = " ".join(parts) + "\n"
                 file.write(line)
 


### PR DESCRIPTION
## Problem

`prepare_directory.__dockerfile_copy_from()` rewrites context-relative `COPY`
sources to the `service/`-prefixed build context (project files are placed under
`.service/service/` during preparation — see the README's *COPY Path Adjustment*
section). But it only rewrites `parts[1]` — the **first** source argument.

A multi-source `COPY` therefore breaks. Given:

```dockerfile
COPY ./a ./b /dst/
```

the packer produces:

```dockerfile
COPY service/a ./b /dst/
```

`./b` now resolves outside the `service/` build context and the build fails with
`"/b": not found`. This bit a real service whose Dockerfile had
`COPY ./ide/bin/new-service ./ide/bin/pack-service /usr/local/bin/` — only the
first file was found.

## Fix

Rewrite **every** context source (all args between `COPY`/its flags and the final
destination) that starts with `.`:

- `--from=<stage>` COPYs reference a build *stage*, not the build context, so they
  are explicitly left untouched.
- `--chown=` / `--chmod=` flags are skipped over (not treated as sources).
- Single-source COPYs are unchanged.

## Verification

| Input | Output |
|---|---|
| `COPY ./a ./b /dst/` | `COPY service/a service/b /dst/` ✅ |
| `COPY ./src /app/src` | `COPY service/src /app/src` ✅ |
| `COPY --from=builder /build/app.jar /app/` | unchanged ✅ |
| `COPY --from=builder ./x /y` | unchanged (has `--from`) ✅ |
| `COPY --chown=www:www ./src ./conf /var/www/` | `COPY --chown=www:www service/src service/conf /var/www/` ✅ |

## Related (not fixed here)

When the underlying `docker buildx build` fails, `nodo pack` still returns **exit
status 0** — a build failure reads as success to any CI/automation driving the
packer. Flagging it here; happy to open a separate PR to surface a non-zero exit
on build failure if useful.
