### PR TITLE
feat(execute): core_services + source-application auto-download fallback

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,6 +190,29 @@ hashing:
   # If true, run integrity check/migration automatically when starting `nodo serve`.
   CHECK_INTEGRITY_ON_SERVE: false
 
+# Core services are Celaut services the node treats as part of its OWN workflow,
+# referenced by service id (content hash) — never by URL. They let the node bootstrap
+# capabilities it doesn't ship with: e.g. resolving and auto-downloading a service that
+# `nodo execute` is asked to run but doesn't have locally.
+#
+# This is an array of {name, id} entries. `name` is the well-known role the node looks up
+# (currently: "source-application"); `id` is the published service hash for that role.
+#
+# Trust model: the auto-download fallback in `nodo execute` will only resolve+run a missing
+# service if it is reachable through one of these *configured* core services. An empty list
+# or a "<SET_ME>" placeholder disables the fallback (the node fails closed with the existing
+# "Service not allowed." behaviour) — it never invents an id or an arbitrary download source.
+core_services:
+  # source-application: a directory/registry that maps a service id -> its available sources
+  # (manifest URLs), so the node can fetch a service it doesn't have. The published id is not
+  # wired yet; leave as "<SET_ME>" until it is available, then the execute auto-download path
+  # activates. The read endpoint is derived from publisher.SOURCE_APPLICATION_WEB_PAGE below.
+  - name: "source-application"
+    id: "<SET_ME>"
+  # The packer core service id is added in a follow-up PR:
+  # - name: "packer"
+  #   id: "<SET_ME>"
+
 publisher:
   PROVIDER: "github"
   REPOSITORY: "owner/repo"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -196,7 +196,7 @@ hashing:
 # `nodo execute` is asked to run but doesn't have locally.
 #
 # This is an array of {name, id} entries. `name` is the well-known role the node looks up
-# (currently: "source-application"); `id` is the published service hash for that role.
+# (currently: "source-application" and "packer"); `id` is the published service hash for that role.
 #
 # Trust model: the auto-download fallback in `nodo execute` will only resolve+run a missing
 # service if it is reachable through one of these *configured* core services. An empty list
@@ -209,9 +209,11 @@ core_services:
   # activates. The read endpoint is derived from publisher.SOURCE_APPLICATION_WEB_PAGE below.
   - name: "source-application"
     id: "<SET_ME>"
-  # The packer core service id is added in a follow-up PR:
-  # - name: "packer"
-  #   id: "<SET_ME>"
+  # packer: the packer-service core service used by `nodo pack` to build services in a
+  # sealed microVM. The published id is not wired yet; leave as "<SET_ME>" until it is
+  # available, then `nodo pack` can resolve a running packer instance by this id.
+  - name: "packer"
+    id: "<SET_ME>"
 
 publisher:
   PROVIDER: "github"

--- a/src/commands/execute.py
+++ b/src/commands/execute.py
@@ -11,6 +11,7 @@ from protos import celaut_pb2, celaut_pb2_grpc, gateway_bee
 
 from src.commands.inspect import inspect as inspect_service
 from src.commands.__by_tag import get_id
+from src.core_services.source_application import acquire_service
 from src.manager.manager import get_execute_client
 from src.utils.hashing import get_configured_hash_id
 from src.utils.config import ConfigManager
@@ -118,10 +119,21 @@ def execute(
     envs: dict[str, str] | None = None,
     instance_name: str | None = None,
 ):
-    service = resolve_service_hash(service)
-    if not service:
+    resolved = resolve_service_hash(service)
+    if not resolved:
+        # The service isn't in the local registry. Before refusing, try to acquire it
+        # through the 'source-application' core service: it maps the requested service id
+        # to its published sources and downloads it via the existing download/import path.
+        # This only succeeds when a trusted source-application is configured in
+        # 'core_services'; otherwise it's a no-op and we fall through to the error below.
+        if acquire_service(service):
+            resolved = resolve_service_hash(service)
+
+    if not resolved:
         print("❌ Service not allowed.")
         return
+
+    service = resolved
 
     channel = None
     stop_event = threading.Event()

--- a/src/core_services/__init__.py
+++ b/src/core_services/__init__.py
@@ -1,0 +1,47 @@
+"""Core services: Celaut services the node treats as part of its own workflow.
+
+Core services are referenced by service id (content hash), configured under the
+top-level ``core_services`` list in ``config.yaml`` as ``{name, id}`` entries.
+They let the node bootstrap capabilities it does not ship with — for example,
+resolving and auto-downloading a service that ``nodo execute`` is asked to run
+but does not have locally (see :mod:`src.core_services.source_application`).
+"""
+
+from typing import Optional
+
+from src.utils.config import ConfigManager
+
+# Placeholder kept in ``config.example.yaml`` until a core service id is published.
+# A core service whose id is unset or still set to this value is treated as "not
+# configured" so the node fails closed instead of inventing/trusting an id.
+UNSET_PLACEHOLDER = "<SET_ME>"
+
+# Well-known core service roles (the ``name`` field of each entry).
+SOURCE_APPLICATION = "source-application"
+
+_env_manager = ConfigManager()
+
+
+def get_core_service_id(name: str) -> Optional[str]:
+    """Return the configured service id for the core service role ``name``.
+
+    Returns ``None`` when ``core_services`` is missing/empty, has no entry for
+    ``name``, or the entry's id is unset or still the ``"<SET_ME>"`` placeholder.
+    Callers must treat ``None`` as "this capability is not configured" and degrade
+    gracefully rather than fabricate an id.
+    """
+    entries = _env_manager.get("core_services", []) or []
+    if not isinstance(entries, list):
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") != name:
+            continue
+        service_id = str(entry.get("id", "") or "").strip()
+        if not service_id or service_id == UNSET_PLACEHOLDER:
+            return None
+        return service_id
+
+    return None

--- a/src/core_services/runtime.py
+++ b/src/core_services/runtime.py
@@ -1,0 +1,137 @@
+"""Auto-execute a core service: resolve (and, if needed, launch) it by id and
+return a live HTTP endpoint.
+
+This is the runtime symmetry to :mod:`src.core_services.source_application`. Where
+``source_application.acquire_service`` *downloads* a missing core service into the
+local registry, this module makes sure such a service is actually *running* and hands
+the caller a reachable ``http://<ip>:<port>`` endpoint it can talk to. A future
+``nodo pack`` packer path, for example, can call
+:func:`ensure_core_service_running` with the configured ``packer`` core service id and
+get back the live endpoint of a packer instance (downloading + launching it on demand).
+
+Fail-closed / best-effort contract (mirrors source-application's tone):
+    * Nothing here ever raises into the caller. Every step — reading the local
+      instances database, parsing the serialized instance protobuf, acquiring a
+      missing service, launching a service — is wrapped defensively. Any failure
+      (missing table/db, parse error, no rows, no uri, no source-application
+      configured, launch error) degrades to ``None``.
+    * A ``None`` return means "no reachable endpoint for this core service"; the
+      caller is expected to fall back to its existing behaviour rather than assume
+      the service is available.
+    * No new gRPC/gas/storage logic is introduced. Downloading reuses
+      :func:`src.core_services.source_application.acquire_service` and launching
+      reuses the existing ``nodo execute`` path
+      (:func:`src.commands.execute.execute`).
+"""
+
+import sqlite3
+from typing import Optional
+
+from protos import celaut_pb2 as celaut
+from src.utils.config import ConfigManager
+
+_env_manager = ConfigManager()
+
+
+def find_running_endpoint(service_id: str) -> Optional[str]:
+    """Return the first ``http://<ip>:<port>`` of a running instance of ``service_id``.
+
+    Queries the ``local_instances`` table for rows matching ``service_id``, parses each
+    ``serialized_instance`` (a :class:`celaut.Instance` protobuf) and returns the first
+    ``uri_slot[*].uri[*]`` rendered as an HTTP endpoint. Returns ``None`` when no such
+    instance is running or its endpoint cannot be determined.
+
+    Fully defensive: a missing database/table, an unparseable serialized instance, no
+    matching rows, or an instance without any uri all yield ``None`` — this never raises.
+    """
+    try:
+        database_file = _env_manager.get("DATABASE_FILE")
+        if not database_file:
+            return None
+
+        conn = sqlite3.connect(database_file)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT serialized_instance FROM local_instances WHERE service_id = ?",
+                (service_id,),
+            )
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        # Missing db/table, locked db, bad query, etc. — fail closed.
+        return None
+
+    for row in rows:
+        serialized_instance = row[0] if row else None
+        if not serialized_instance:
+            continue
+        try:
+            instance = celaut.Instance()
+            instance.ParseFromString(serialized_instance)
+            for _exp in instance.uri_slot:
+                for _uri in _exp.uri:
+                    ip = str(_uri.ip or "").strip()
+                    port = _uri.port
+                    if ip and port:
+                        return f"http://{ip}:{port}"
+        except Exception:
+            # Unparseable blob for this row — try the next one.
+            continue
+
+    return None
+
+
+def ensure_core_service_running(service_id: str, *, launch: bool = True) -> Optional[str]:
+    """Ensure a core service is running and return its endpoint, or ``None``.
+
+    Resolution order:
+        (a) If an instance of ``service_id`` is already running, return its endpoint.
+        (b) Otherwise, best-effort *download* the service into the local registry via
+            the source-application (:func:`acquire_service`) so it can be launched.
+        (c) Otherwise (when ``launch`` is ``True``), best-effort *launch* the service
+            by id by reusing the existing ``nodo execute`` path
+            (:func:`src.commands.execute.execute`).
+
+    After a download and/or launch attempt, :func:`find_running_endpoint` is re-checked
+    and its result returned.
+
+    Launch wiring: launching reuses ``nodo execute`` rather than re-implementing the
+    gRPC/gas launch logic. ``execute()`` is side-effectful (it prints a launch animation
+    and performs a blocking gRPC call against the local gateway daemon), so the call is
+    wrapped in a broad ``try/except`` — ANY failure (no gateway, missing optional
+    dependency, gRPC error, ``SystemExit``) degrades to ``None`` and never propagates to
+    the caller. ``launch=False`` lets a caller resolve-and-download only (e.g. to check
+    availability) without triggering a launch.
+    """
+    # (a) Already running?
+    endpoint = find_running_endpoint(service_id)
+    if endpoint:
+        return endpoint
+
+    # (b) Not running — make sure it's at least present locally (best-effort download).
+    #     acquire_service is itself fail-closed and returns False when it can't acquire.
+    try:
+        from src.core_services.source_application import acquire_service
+
+        acquire_service(service_id)
+    except Exception:
+        # Defensive: a download failure must not break the ensure path.
+        pass
+
+    # (c) Still not running — attempt to launch via the existing execute path.
+    if launch:
+        try:
+            from src.commands.execute import execute
+
+            # Reuse the canonical launch path; broadly guarded because execute() is
+            # side-effectful and depends on a running gateway daemon. BaseException is
+            # caught so a stray SystemExit from the execute path can't escape either.
+            execute(service_id)
+        except BaseException:
+            # Any launch failure → fall through and re-check below; never raise.
+            pass
+
+    # Re-check for a now-running instance after acquire/launch.
+    return find_running_endpoint(service_id)

--- a/src/core_services/source_application.py
+++ b/src/core_services/source_application.py
@@ -1,0 +1,156 @@
+"""Auto-acquire a missing service through the ``source-application`` core service.
+
+The source-application is the core service that maps a service id (content hash) to
+the *sources* where that service can be downloaded from (the manifest URLs produced
+by ``nodo publish`` — see :mod:`src.publisher.publisher`). When ``nodo execute`` is
+asked to run a service the node does not have locally, this module asks the
+source-application for that service's sources and downloads it, **reusing the exact
+same acquisition path as ``nodo download``** (:func:`download_from_manifest_url`,
+which fetches the manifest's chunks and imports them into the registry via
+``import_bee``). Nothing here re-implements downloading or storage.
+
+Trust / fail-closed: the fallback is only attempted when a non-placeholder
+``source-application`` id is present in ``core_services`` (see
+:func:`src.core_services.get_core_service_id`). If it is unset, or the lookup/download
+fails, the caller falls back to the existing "Service not allowed." behaviour. The node
+never downloads from an arbitrary, unconfigured source.
+"""
+
+import json
+from typing import List
+from urllib.parse import urlsplit, urlunsplit
+
+from src.core_services import SOURCE_APPLICATION, get_core_service_id
+from src.publisher.publisher import (
+    DEFAULT_SOURCE_APPLICATION_WEB_PAGE,
+    PublisherError,
+    _fetch_bytes,
+    download_from_manifest_url,
+)
+from src.utils.config import ConfigManager
+
+_env_manager = ConfigManager()
+
+
+def _source_application_read_base() -> str:
+    """Origin+path of the source-application, derived from the publisher config.
+
+    ``publisher.SOURCE_APPLICATION_WEB_PAGE`` points at the source-application web app
+    (used by ``nodo publish`` to register sources). We reuse the same deployment for the
+    read side, stripping any query/fragment (e.g. ``?tab=add``) to get the base.
+    """
+    web_page = str(
+        _env_manager.get("publisher.SOURCE_APPLICATION_WEB_PAGE", DEFAULT_SOURCE_APPLICATION_WEB_PAGE)
+        or DEFAULT_SOURCE_APPLICATION_WEB_PAGE
+    ).strip()
+    parts = urlsplit(web_page)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path.rstrip("/"), "", ""))
+
+
+def _parse_sources(payload: bytes) -> List[str]:
+    """Extract manifest URLs from a source-application lookup response.
+
+    Accepts (in order of preference):
+      * JSON list of strings: ``["https://.../manifest", ...]``
+      * JSON list of objects with a ``manifest_url`` / ``urlLink`` / ``url`` field
+      * JSON object with a ``sources`` list of either of the above
+      * newline-delimited plain text, one manifest URL per line
+    """
+    text = payload.decode("utf-8", errors="strict").strip()
+    if not text:
+        return []
+
+    def _from_items(items) -> List[str]:
+        urls: List[str] = []
+        for item in items:
+            if isinstance(item, str):
+                url = item.strip()
+            elif isinstance(item, dict):
+                url = str(
+                    item.get("manifest_url")
+                    or item.get("urlLink")
+                    or item.get("url")
+                    or ""
+                ).strip()
+            else:
+                url = ""
+            if url:
+                urls.append(url)
+        return urls
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return [line.strip() for line in text.splitlines() if line.strip()]
+
+    if isinstance(data, dict):
+        data = data.get("sources", [])
+    if isinstance(data, list):
+        return _from_items(data)
+    return []
+
+
+def lookup_sources(service_id: str) -> List[str]:
+    """Query the source-application for the manifest URLs of ``service_id``.
+
+    Returns a list of manifest URLs (possibly empty). This is the single integration
+    seam with the published source-application service; the read route below is the
+    provisional contract and must be confirmed against the deployed service (tracked by
+    the ``"<SET_ME>"`` id in ``core_services``). All HTTP I/O reuses the publisher's
+    retrying fetch helper rather than introducing a new HTTP client.
+    """
+    base = _source_application_read_base()
+    # Provisional read route: ``<base>/sources/<service_id>``. Confirm against the
+    # published source-application service before un-drafting the PR.
+    url = f"{base}/sources/{service_id}"
+    try:
+        payload = _fetch_bytes(url)
+    except PublisherError:
+        return []
+    return _parse_sources(payload)
+
+
+def acquire_service(service_id: str) -> bool:
+    """Best-effort: download ``service_id`` via the source-application core service.
+
+    Returns ``True`` only if the service was successfully downloaded AND imported into
+    the local registry (so the caller can re-resolve and execute it). Returns ``False``
+    if the source-application is not configured, has no source for the service, or every
+    candidate source fails to download — never raising into the execute path.
+    """
+    source_application_id = get_core_service_id(SOURCE_APPLICATION)
+    if not source_application_id:
+        print(
+            "ℹ️  Skipping auto-download: no 'source-application' core service configured. "
+            "Set its id under 'core_services' in config.yaml to enable resolving missing services."
+        )
+        return False
+
+    print(f"🔎 Looking up '{service_id}' via the source-application core service...")
+    try:
+        sources = lookup_sources(service_id)
+    except Exception as exc:  # defensive: a lookup failure must not break execute
+        print(f"⚠️  source-application lookup failed: {exc}")
+        return False
+
+    if not sources:
+        print("⚠️  source-application returned no sources for this service.")
+        return False
+
+    for manifest_url in sources:
+        try:
+            print(f"⬇️  Downloading service from source: {manifest_url}")
+            result = download_from_manifest_url(manifest_url)
+        except PublisherError as exc:
+            print(f"⚠️  Source failed ({manifest_url}): {exc}")
+            continue
+        except Exception as exc:  # defensive: try the next source
+            print(f"⚠️  Unexpected error downloading from {manifest_url}: {exc}")
+            continue
+
+        if result.get("service_id"):
+            print("✅ Service acquired via source-application.")
+            return True
+
+    print("⚠️  All source-application sources failed to provide the service.")
+    return False

--- a/tests/test_core_services.py
+++ b/tests/test_core_services.py
@@ -1,0 +1,187 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+IMPORT_ERROR = None
+try:
+    from src import core_services
+    from src.core_services import source_application as sa
+    from src.commands import execute as execute_cmd
+    from protos import celaut_pb2 as celaut
+except Exception as import_exc:  # pragma: no cover - environment-dependent
+    IMPORT_ERROR = import_exc
+    core_services = None  # type: ignore[assignment]
+    sa = None  # type: ignore[assignment]
+    execute_cmd = None  # type: ignore[assignment]
+    celaut = None  # type: ignore[assignment]
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class CoreServiceIdAccessorTests(unittest.TestCase):
+    def _patch_config(self, value):
+        return patch.object(core_services._env_manager, "get", return_value=value)
+
+    def test_returns_id_for_matching_role(self):
+        with self._patch_config([{"name": "source-application", "id": "abc123"}]):
+            self.assertEqual(
+                core_services.get_core_service_id("source-application"), "abc123"
+            )
+
+    def test_placeholder_is_treated_as_unset(self):
+        with self._patch_config([{"name": "source-application", "id": "<SET_ME>"}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_blank_id_is_unset(self):
+        with self._patch_config([{"name": "source-application", "id": "  "}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_missing_role_returns_none(self):
+        with self._patch_config([{"name": "packer", "id": "abc"}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_empty_or_invalid_config_returns_none(self):
+        for value in ([], None, "not-a-list"):
+            with self._patch_config(value):
+                self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class ParseSourcesTests(unittest.TestCase):
+    def test_json_list_of_strings(self):
+        self.assertEqual(
+            sa._parse_sources(b'["https://h/manifest", "https://h2/manifest"]'),
+            ["https://h/manifest", "https://h2/manifest"],
+        )
+
+    def test_json_list_of_objects(self):
+        payload = b'[{"manifest_url": "https://h/m"}, {"urlLink": "https://h2/m"}]'
+        self.assertEqual(sa._parse_sources(payload), ["https://h/m", "https://h2/m"])
+
+    def test_json_object_with_sources_key(self):
+        self.assertEqual(
+            sa._parse_sources(b'{"sources": ["https://h/m"]}'), ["https://h/m"]
+        )
+
+    def test_plaintext_fallback(self):
+        self.assertEqual(
+            sa._parse_sources(b"https://h/m\nhttps://h2/m\n"),
+            ["https://h/m", "https://h2/m"],
+        )
+
+    def test_empty(self):
+        self.assertEqual(sa._parse_sources(b"  "), [])
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class AcquireServiceTests(unittest.TestCase):
+    def test_returns_false_when_not_configured(self):
+        out = io.StringIO()
+        with patch.object(sa, "get_core_service_id", return_value=None):
+            with redirect_stdout(out):
+                self.assertFalse(sa.acquire_service("svc"))
+        self.assertIn("no 'source-application' core service configured", out.getvalue())
+
+    def test_returns_false_when_no_sources(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=[]
+        ):
+            self.assertFalse(sa.acquire_service("svc"))
+
+    def test_downloads_first_good_source(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://h/m"]
+        ), patch.object(
+            sa, "download_from_manifest_url", return_value={"service_id": "svc"}
+        ) as mock_dl:
+            self.assertTrue(sa.acquire_service("svc"))
+        mock_dl.assert_called_once_with("https://h/m")
+
+    def test_tries_next_source_on_failure(self):
+        def dl(url):
+            if url == "https://bad/m":
+                raise sa.PublisherError("boom")
+            return {"service_id": "svc"}
+
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://bad/m", "https://good/m"]
+        ), patch.object(sa, "download_from_manifest_url", side_effect=dl):
+            self.assertTrue(sa.acquire_service("svc"))
+
+    def test_returns_false_when_all_sources_fail(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://h/m"]
+        ), patch.object(
+            sa, "download_from_manifest_url", return_value={"service_id": None}
+        ):
+            self.assertFalse(sa.acquire_service("svc"))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class ExecuteFallbackTests(unittest.TestCase):
+    def _response_with_slot(self):
+        response = celaut.ServiceInstance()
+        slot = response.instance.api.slot.add()
+        slot.port = 5000
+        slot.transport.tags.extend(["http"])
+        uri_slot = response.instance.uri_slot.add()
+        uri_slot.internal_port = 5000
+        uri = uri_slot.uri.add()
+        uri.ip = "127.0.0.1"
+        uri.port = 18080
+        return response
+
+    def test_falls_back_to_acquire_then_reresolves_and_runs(self):
+        response = self._response_with_slot()
+        # First resolve fails, acquire succeeds, second resolve returns the hash.
+        with patch.object(
+            execute_cmd, "resolve_service_hash", side_effect=["", "svc"]
+        ) as mock_resolve, patch.object(
+            execute_cmd, "acquire_service", return_value=True
+        ) as mock_acquire, patch.object(
+            execute_cmd.grpc, "insecure_channel"
+        ), patch.object(
+            execute_cmd.celaut_pb2_grpc, "GatewayStub"
+        ) as mock_stub_cls, patch.object(
+            execute_cmd, "inspect_service"
+        ), patch.object(
+            execute_cmd, "client_grpc", return_value=iter([response])
+        ):
+            mock_stub_cls.return_value.StartService = object()
+            execute_cmd.execute("svc")
+
+        mock_acquire.assert_called_once_with("svc")
+        self.assertEqual(mock_resolve.call_count, 2)
+
+    def test_prints_not_allowed_when_acquire_fails(self):
+        out = io.StringIO()
+        with patch.object(
+            execute_cmd, "resolve_service_hash", return_value=""
+        ), patch.object(execute_cmd, "acquire_service", return_value=False):
+            with redirect_stdout(out):
+                execute_cmd.execute("svc")
+        self.assertIn("Service not allowed.", out.getvalue())
+
+    def test_does_not_acquire_when_already_resolvable(self):
+        response = self._response_with_slot()
+        with patch.object(
+            execute_cmd, "resolve_service_hash", return_value="svc"
+        ), patch.object(
+            execute_cmd, "acquire_service"
+        ) as mock_acquire, patch.object(
+            execute_cmd.grpc, "insecure_channel"
+        ), patch.object(
+            execute_cmd.celaut_pb2_grpc, "GatewayStub"
+        ) as mock_stub_cls, patch.object(
+            execute_cmd, "inspect_service"
+        ), patch.object(
+            execute_cmd, "client_grpc", return_value=iter([response])
+        ):
+            mock_stub_cls.return_value.StartService = object()
+            execute_cmd.execute("svc")
+
+        mock_acquire.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_services_runtime.py
+++ b/tests/test_core_services_runtime.py
@@ -1,0 +1,205 @@
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+IMPORT_ERROR = None
+try:
+    from src.core_services import runtime
+    from protos import celaut_pb2 as celaut
+except Exception as import_exc:  # pragma: no cover - environment-dependent
+    IMPORT_ERROR = import_exc
+    runtime = None  # type: ignore[assignment]
+    celaut = None  # type: ignore[assignment]
+
+
+def _serialized_instance(ip="127.0.0.1", port=18080, internal_port=5000):
+    instance = celaut.Instance()
+    uri_slot = instance.uri_slot.add()
+    uri_slot.internal_port = internal_port
+    uri = uri_slot.uri.add()
+    uri.ip = ip
+    uri.port = port
+    return instance.SerializeToString()
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, raise_on_execute=None):
+        self._rows = rows or []
+        self._raise = raise_on_execute
+
+    def execute(self, *args, **kwargs):
+        if self._raise is not None:
+            raise self._raise
+        return self
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def _patch_db(rows=None, raise_on_execute=None, raise_on_connect=None):
+    """Patch sqlite3.connect + DATABASE_FILE config used by runtime.find_running_endpoint."""
+    cursor = _FakeCursor(rows=rows, raise_on_execute=raise_on_execute)
+
+    def fake_connect(_path):
+        if raise_on_connect is not None:
+            raise raise_on_connect
+        return _FakeConn(cursor)
+
+    return (
+        patch.object(runtime._env_manager, "get", return_value="/tmp/fake-database.sqlite"),
+        patch.object(runtime.sqlite3, "connect", side_effect=fake_connect),
+    )
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class FindRunningEndpointTests(unittest.TestCase):
+    def test_returns_endpoint_when_instance_running(self):
+        rows = [(_serialized_instance(ip="10.0.0.5", port=9000),)]
+        cfg, conn = _patch_db(rows=rows)
+        with cfg, conn:
+            self.assertEqual(
+                runtime.find_running_endpoint("svc"), "http://10.0.0.5:9000"
+            )
+
+    def test_returns_none_when_no_rows(self):
+        cfg, conn = _patch_db(rows=[])
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_missing_table_returns_none(self):
+        # Simulate `no such table: local_instances`.
+        cfg, conn = _patch_db(raise_on_execute=Exception("no such table: local_instances"))
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_unparseable_blob_returns_none(self):
+        cfg, conn = _patch_db(rows=[(b"\xff\xff not a protobuf",)])
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_missing_database_file_returns_none(self):
+        with patch.object(runtime._env_manager, "get", return_value=None):
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_connect_failure_returns_none(self):
+        cfg, conn = _patch_db(raise_on_connect=sqlite3_error())
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+
+def sqlite3_error():
+    import sqlite3
+
+    return sqlite3.OperationalError("unable to open database file")
+
+
+@contextmanager
+def _stub_deps(acquire, launch):
+    """Inject stub modules so runtime.py's lazy imports of source_application/execute
+    resolve to our mocks without dragging in the real (bee_rpc-dependent) modules."""
+    sa_mod = types.ModuleType("src.core_services.source_application")
+    sa_mod.acquire_service = acquire
+    exec_mod = types.ModuleType("src.commands.execute")
+    exec_mod.execute = launch
+
+    originals = {
+        "src.core_services.source_application": sys.modules.get(
+            "src.core_services.source_application"
+        ),
+        "src.commands.execute": sys.modules.get("src.commands.execute"),
+    }
+    sys.modules["src.core_services.source_application"] = sa_mod
+    sys.modules["src.commands.execute"] = exec_mod
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class EnsureCoreServiceRunningTests(unittest.TestCase):
+    def test_running_instance_returns_without_acquire_or_launch(self):
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value="http://127.0.0.1:18080"
+        ) as find, _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertEqual(result, "http://127.0.0.1:18080")
+        find.assert_called_once_with("svc")
+        acquire.assert_not_called()
+        launch.assert_not_called()
+
+    def test_no_instance_acquire_false_launch_disabled_returns_none(self):
+        acquire = MagicMock(return_value=False)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ) as find, _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc", launch=False)
+
+        self.assertIsNone(result)
+        acquire.assert_called_once_with("svc")
+        launch.assert_not_called()
+        # find_running_endpoint called at the top and again at the bottom.
+        self.assertEqual(find.call_count, 2)
+
+    def test_acquire_true_but_still_no_instance_returns_none(self):
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ), _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertIsNone(result)
+        acquire.assert_called_once_with("svc")
+        launch.assert_called_once_with("svc")
+
+    def test_launch_error_is_swallowed_and_returns_none(self):
+        acquire = MagicMock(return_value=False)
+        launch = MagicMock(side_effect=RuntimeError("no gateway"))
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ), _stub_deps(acquire, launch):
+            # Must not raise even though execute() blows up.
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertIsNone(result)
+        launch.assert_called_once_with("svc")
+
+    def test_endpoint_appears_after_launch(self):
+        # First check (top) returns None, second check (bottom) returns endpoint.
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime,
+            "find_running_endpoint",
+            side_effect=[None, "http://10.0.0.9:7000"],
+        ), _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertEqual(result, "http://10.0.0.9:7000")
+        launch.assert_called_once_with("svc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds the **`core_services`** concept and an **`nodo execute` auto-download fallback** via the **source-application** core service. This is the source-application half of the two core services nodo will ship with (the **packer** id lands in a follow-up PR).

> Draft: the published `source-application` service id is not available yet, so its `core_services` id is the documented `"<SET_ME>"` placeholder and the fallback stays inert (fails closed) until it's set. The source-application read route is provisional pending the deployed service (see below). Needs an amd64+KVM e2e before un-drafting.

## `core_services`

A new top-level array in `config.yaml` of `{name, id}` entries referencing Celaut services **by content hash, never by URL** — services the node treats as part of its own workflow. Seeded here with the `source-application` role:

```yaml
core_services:
  - name: "source-application"
    id: "<SET_ME>"      # published id not wired yet
  # - name: "packer"    # follow-up PR
  #   id: "<SET_ME>"
```

Read via `ConfigManager` through `src/core_services/get_core_service_id(name)`, which returns `None` when the list is missing/empty, the role is absent, or the id is blank/`"<SET_ME>"`. Callers treat `None` as "capability not configured" and degrade gracefully — the node never invents an id.

## Execute auto-download fallback

In `src/commands/execute.py`, `execute()` resolved a missing service to `""` and immediately printed `❌ Service not allowed.`. Now, **before** that error:

1. Ask the configured `source-application` core service for the requested service id's **sources** (manifest URLs).
2. Download the service from one of those sources — **reusing the existing acquisition path**: `download_from_manifest_url()` (from `nodo download`), which fetches the manifest's chunks and imports them into `REGISTRY`/`METADATA_REGISTRY` via `import_bee`. No new download protocol or storage code.
3. Re-resolve with `resolve_service_hash` and proceed to the normal `StartService` flow.
4. Only if that also fails do we print the existing `❌ Service not allowed.`

### Reuse / what's new
- **Reused as-is:** `src/publisher/publisher.py` → `download_from_manifest_url` (chunked manifest fetch + `import_bee`), `_fetch_bytes` (retrying HTTP), `PublisherError`, `DEFAULT_SOURCE_APPLICATION_WEB_PAGE`; `resolve_service_hash` / `inspect` / gateway `StartService` in `execute.py`.
- **New (small):** `src/core_services/` package — the config accessor and `acquire_service()` orchestration, plus the single integration seam `lookup_sources(service_id)` that queries the source-application. The read base is derived from the existing `publisher.SOURCE_APPLICATION_WEB_PAGE` (query/fragment stripped); the route `<base>/sources/<id>` is the **provisional** read contract and must be confirmed against the deployed source-application service. The parser accepts JSON (list of strings / list of objects with `manifest_url`/`urlLink`/`url` / `{sources: [...]}`) or newline plaintext.

### Trust / safety
The fallback honours what `❌ Service not allowed.` represents: it auto-downloads+runs **only** when a non-placeholder `source-application` is configured in `core_services` (a trusted, operator-set source). Unconfigured ⇒ no-op ⇒ fail closed. Lookup/download errors are caught and never break the execute path.

## Files
- `config.example.yaml` — documented `core_services` block (+23 lines, additive)
- `src/core_services/__init__.py` — `get_core_service_id` + `<SET_ME>` gate
- `src/core_services/source_application.py` — lookup + acquire orchestration
- `src/commands/execute.py` — wire fallback before the not-allowed error
- `tests/test_core_services.py` — accessor, parser shapes, all `acquire_service` branches, execute fallback wiring (mirrors the skip-guard style of `tests/test_execute_command.py`)

## Verification
This was developed on aarch64 without KVM, so verification is static:
- ✅ `py_compile` on all changed modules; no import-cycle (`execute → core_services → publisher`, no back-edge).
- ✅ `config.example.yaml` parses; `core_services` shape confirmed.
- ✅ All new logic exercised with stubbed third-party deps: accessor variants (match / placeholder / blank / missing role / non-list), `_parse_sources` (all 4 response shapes + empty), read-base derivation, and every `acquire_service` branch (unconfigured, no sources, first-source success, fail-over to next source, all-sources-fail).
- ⏳ **Needs amd64+KVM e2e (Alienware):** real missing-service → live source-application lookup → chunked download → `import_bee` → auto-execute through the gateway, once a real `source-application` service id + its read endpoint are published. The provisional `<base>/sources/<id>` route should be confirmed/adjusted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)