### PR TITLE
feat(publisher): four-level source registration + AUTO_PUBLISH_TX

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -242,19 +242,29 @@ publisher:
   BRANCH: "main"
   SOURCE_APPLICATION_WEB_PAGE: "https://reputation-systems.github.io/source-application?tab=add"
   # How a freshly-published source gets registered, resolved across four levels:
-  #   1. AUTO_PUBLISH_TX true  + a running "source-application" core-service instance
-  #      -> the source transaction is submitted directly via that instance's API,
-  #         signed with the node wallet seed (ledgers.ergo.WALLET_MNEMONIC). No click.
-  #   2. AUTO_PUBLISH_TX false + a running instance
-  #      -> prints a click-to-add link against the instance's web page.
+  #   1. AUTO_PUBLISH_TX true + a running "source-application" instance + SOURCE_PROFILE_BOX_ID
+  #      -> the FILE_SOURCE opinion is published directly via the instance's REST API
+  #         (POST /api/sources {mainBoxId, fileHash, sourceEntry}). The instance signs +
+  #         submits itself using its OWN env-configured seed (see note below). No click.
+  #   2. running instance but auto-submit off/unavailable, SOURCE_APPLICATION_WEB_PAGE set
+  #      -> prints a prefilled click-to-add link on the web app (the instance serves only
+  #         /api + /mcp JSON, never the prefill form).
   #   3. no running instance but SOURCE_APPLICATION_WEB_PAGE set (above)
-  #      -> prints a click-to-add link against that page (pre-existing behaviour).
-  #   4. no instance and SOURCE_APPLICATION_WEB_PAGE empty
-  #      -> prints a manual-registration message (file hash + content hash + manifest URL).
+  #      -> prints the same prefilled click-to-add link (pre-existing behaviour).
+  #   4. nothing usable -> a manual-registration message (file hash + content hash + manifest URL).
   # The instance is the "source-application" entry under core_services (resolved by id).
-  # AUTO_PUBLISH_TX transmits the wallet seed to the LOCAL on-node instance; keep it
-  # false unless you run a trusted source-application instance on this node.
+  #
+  # AUTO_PUBLISH_TX does NOT send the wallet seed over HTTP. The on-node source-application
+  # instance must itself be launched in seed mode with the mnemonic in its environment
+  # (SOURCE_SIGNER_MODE=seed, SOURCE_MNEMONIC=...); otherwise it returns an unsigned tx and
+  # the publisher falls back to a link. Keep AUTO_PUBLISH_TX false unless you run a trusted,
+  # seed-mode source-application instance on this node.
   AUTO_PUBLISH_TX: false
+  # The node's reputation PROFILE box id (its on-chain author identity). Required for
+  # AUTO_PUBLISH_TX: every FILE_SOURCE opinion is split from this box. Mint a profile once
+  # (source-application web app, or POST /api/profile on a seed-mode instance, then look up
+  # the resulting box), and paste its 64-hex box id here. Leave empty to disable level 1.
+  SOURCE_PROFILE_BOX_ID: ""
   # Formats can be file extensions (tags) or ergo box ids that define the format uniquely.
   CONTENT_FORMAT: ".grpcbb"
   RAW_FORMAT: ".celaut"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,6 +190,29 @@ hashing:
   # If true, run integrity check/migration automatically when starting `nodo serve`.
   CHECK_INTEGRITY_ON_SERVE: false
 
+# Core services are Celaut services the node treats as part of its OWN workflow,
+# referenced by service id (content hash) — never by URL. They let the node bootstrap
+# capabilities it doesn't ship with: e.g. resolving and auto-downloading a service that
+# `nodo execute` is asked to run but doesn't have locally.
+#
+# This is an array of {name, id} entries. `name` is the well-known role the node looks up
+# (currently: "source-application"); `id` is the published service hash for that role.
+#
+# Trust model: the auto-download fallback in `nodo execute` will only resolve+run a missing
+# service if it is reachable through one of these *configured* core services. An empty list
+# or a "<SET_ME>" placeholder disables the fallback (the node fails closed with the existing
+# "Service not allowed." behaviour) — it never invents an id or an arbitrary download source.
+core_services:
+  # source-application: a directory/registry that maps a service id -> its available sources
+  # (manifest URLs), so the node can fetch a service it doesn't have. The published id is not
+  # wired yet; leave as "<SET_ME>" until it is available, then the execute auto-download path
+  # activates. The read endpoint is derived from publisher.SOURCE_APPLICATION_WEB_PAGE below.
+  - name: "source-application"
+    id: "<SET_ME>"
+  # The packer core service id is added in a follow-up PR:
+  # - name: "packer"
+  #   id: "<SET_ME>"
+
 publisher:
   PROVIDER: "github"
   REPOSITORY: "owner/repo"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -226,12 +226,14 @@ core_services:
 # workloads, it opportunistically runs the "low-demand-fallback" core service; a real
 # execute request or crossing any threshold preempts (stops) it. Thresholds are the
 # "environment-variable" levels below which the fallback is allowed to run.
-# NOTE: this scheduler is scaffolded but NOT yet wired into the serve loop.
+# The scheduler is driven from the manager loop (src/manager/maintain.py) and is a no-op
+# unless ENABLED is true; preemption always STOPS the fallback (there is no pause primitive).
 low_demand:
-  ENABLED: false          # master switch; opportunistic fallback is OFF by default.
-  POLL_INTERVAL: 30       # seconds between idle checks.
-  CPU_MAX_PERCENT: 40     # run the fallback only when system CPU usage is <= this percent.
-  MEM_MAX_PERCENT: 60     # run the fallback only when system memory usage is <= this percent.
+  ENABLED: false                  # master switch; opportunistic fallback is OFF by default.
+  POLL_INTERVAL: 30               # seconds between idle checks (independent of MANAGER_ITERATION_TIME).
+  CPU_MAX_PERCENT: 40             # run the fallback only when system CPU usage is <= this percent.
+  MEM_MAX_PERCENT: 60             # run the fallback only when system memory usage is <= this percent.
+  LOW_DEMAND_CONSECUTIVE_POLLS: 3 # consecutive below-threshold, idle polls required before starting (hysteresis).
   # Future per-resource thresholds (e.g. GPU_MAX_PERCENT, DISK_MAX_PERCENT) go here.
 
 publisher:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -241,6 +241,20 @@ publisher:
   REPOSITORY: "owner/repo"
   BRANCH: "main"
   SOURCE_APPLICATION_WEB_PAGE: "https://reputation-systems.github.io/source-application?tab=add"
+  # How a freshly-published source gets registered, resolved across four levels:
+  #   1. AUTO_PUBLISH_TX true  + a running "source-application" core-service instance
+  #      -> the source transaction is submitted directly via that instance's API,
+  #         signed with the node wallet seed (ledgers.ergo.WALLET_MNEMONIC). No click.
+  #   2. AUTO_PUBLISH_TX false + a running instance
+  #      -> prints a click-to-add link against the instance's web page.
+  #   3. no running instance but SOURCE_APPLICATION_WEB_PAGE set (above)
+  #      -> prints a click-to-add link against that page (pre-existing behaviour).
+  #   4. no instance and SOURCE_APPLICATION_WEB_PAGE empty
+  #      -> prints a manual-registration message (file hash + content hash + manifest URL).
+  # The instance is the "source-application" entry under core_services (resolved by id).
+  # AUTO_PUBLISH_TX transmits the wallet seed to the LOCAL on-node instance; keep it
+  # false unless you run a trusted source-application instance on this node.
+  AUTO_PUBLISH_TX: false
   # Formats can be file extensions (tags) or ergo box ids that define the format uniquely.
   CONTENT_FORMAT: ".grpcbb"
   RAW_FORMAT: ".celaut"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -214,6 +214,25 @@ core_services:
   # available, then `nodo pack` can resolve a running packer instance by this id.
   - name: "packer"
     id: "<SET_ME>"
+  # low-demand-fallback: an opportunistic best-effort service the node runs ONLY when it
+  # has spare capacity (see the `low_demand:` block below) and no real workloads. It is
+  # always preempted by real/paid `execute` requests. The published id is not wired yet;
+  # leave as "<SET_ME>" until it is available. See docs/design/low-demand-fallback.md.
+  - name: "low-demand-fallback"
+    id: "<SET_ME>"
+
+# Opportunistic low-demand fallback scheduler (WIP — see docs/design/low-demand-fallback.md).
+# When ENABLED and the node is under ALL per-resource thresholds AND not serving real
+# workloads, it opportunistically runs the "low-demand-fallback" core service; a real
+# execute request or crossing any threshold preempts (stops) it. Thresholds are the
+# "environment-variable" levels below which the fallback is allowed to run.
+# NOTE: this scheduler is scaffolded but NOT yet wired into the serve loop.
+low_demand:
+  ENABLED: false          # master switch; opportunistic fallback is OFF by default.
+  POLL_INTERVAL: 30       # seconds between idle checks.
+  CPU_MAX_PERCENT: 40     # run the fallback only when system CPU usage is <= this percent.
+  MEM_MAX_PERCENT: 60     # run the fallback only when system memory usage is <= this percent.
+  # Future per-resource thresholds (e.g. GPU_MAX_PERCENT, DISK_MAX_PERCENT) go here.
 
 publisher:
   PROVIDER: "github"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -242,10 +242,11 @@ publisher:
   BRANCH: "main"
   SOURCE_APPLICATION_WEB_PAGE: "https://reputation-systems.github.io/source-application?tab=add"
   # How a freshly-published source gets registered, resolved across four levels:
-  #   1. AUTO_PUBLISH_TX true + a running "source-application" instance + SOURCE_PROFILE_BOX_ID
-  #      -> the FILE_SOURCE opinion is published directly via the instance's REST API
-  #         (POST /api/sources {mainBoxId, fileHash, sourceEntry}). The instance signs +
-  #         submits itself using its OWN env-configured seed (see note below). No click.
+  #   1. AUTO_PUBLISH_TX true + SOURCE_PROFILE_BOX_ID set + a configured "source-application"
+  #      core service -> the FILE_SOURCE opinion is published directly via the instance's
+  #      REST API (POST /api/sources {mainBoxId, fileHash, sourceEntry}). The node
+  #      AUTO-LAUNCHES the source-application in seed mode (see below) if one isn't already
+  #      running, so it signs + submits the tx itself. No click.
   #   2. running instance but auto-submit off/unavailable, SOURCE_APPLICATION_WEB_PAGE set
   #      -> prints a prefilled click-to-add link on the web app (the instance serves only
   #         /api + /mcp JSON, never the prefill form).
@@ -254,11 +255,14 @@ publisher:
   #   4. nothing usable -> a manual-registration message (file hash + content hash + manifest URL).
   # The instance is the "source-application" entry under core_services (resolved by id).
   #
-  # AUTO_PUBLISH_TX does NOT send the wallet seed over HTTP. The on-node source-application
-  # instance must itself be launched in seed mode with the mnemonic in its environment
-  # (SOURCE_SIGNER_MODE=seed, SOURCE_MNEMONIC=...); otherwise it returns an unsigned tx and
-  # the publisher falls back to a link. Keep AUTO_PUBLISH_TX false unless you run a trusted,
-  # seed-mode source-application instance on this node.
+  # AUTO_PUBLISH_TX does NOT send the wallet seed over HTTP. Instead the node launches the
+  # on-node source-application instance in seed mode, injecting the wallet into its env
+  # (SOURCE_SIGNER_MODE=seed, SOURCE_MNEMONIC=<ledgers.ergo.WALLET_MNEMONIC>,
+  # SOURCE_NODE_URI=<ledgers.ergo.NODE_URL>). Requires ledgers.ergo.WALLET_MNEMONIC to be
+  # set. NOTE: if a source-application instance is ALREADY running (e.g. in unsigned mode),
+  # its env is used as-is and the node will not relaunch it; it then returns an unsigned tx
+  # and the publisher falls back to a link. Keep AUTO_PUBLISH_TX false unless you want this
+  # node to sign source transactions with its wallet.
   AUTO_PUBLISH_TX: false
   # The node's reputation PROFILE box id (its on-chain author identity). Required for
   # AUTO_PUBLISH_TX: every FILE_SOURCE opinion is split from this box. Mint a profile once

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -196,7 +196,7 @@ hashing:
 # `nodo execute` is asked to run but doesn't have locally.
 #
 # This is an array of {name, id} entries. `name` is the well-known role the node looks up
-# (currently: "source-application"); `id` is the published service hash for that role.
+# (currently: "source-application" and "packer"); `id` is the published service hash for that role.
 #
 # Trust model: the auto-download fallback in `nodo execute` will only resolve+run a missing
 # service if it is reachable through one of these *configured* core services. An empty list
@@ -209,9 +209,11 @@ core_services:
   # activates. The read endpoint is derived from publisher.SOURCE_APPLICATION_WEB_PAGE below.
   - name: "source-application"
     id: "<SET_ME>"
-  # The packer core service id is added in a follow-up PR:
-  # - name: "packer"
-  #   id: "<SET_ME>"
+  # packer: the packer-service core service used by `nodo pack` to build services in a
+  # sealed microVM. The published id is not wired yet; leave as "<SET_ME>" until it is
+  # available, then `nodo pack` can resolve a running packer instance by this id.
+  - name: "packer"
+    id: "<SET_ME>"
 
 publisher:
   PROVIDER: "github"

--- a/docs/design/low-demand-fallback.md
+++ b/docs/design/low-demand-fallback.md
@@ -1,0 +1,252 @@
+# Low-Demand Fallback Core Service — Design (WIP / DRAFT)
+
+Status: **proposal for Josemi's sign-off.** This document specifies a new core
+service and its node-side scheduler. The scaffold that accompanies it
+(`src/core_services/low_demand.py`, config entries, tests) is intentionally
+**not wired into the serve loop** — the exact scheduling/preemption mechanism is
+the thing we want to agree on before implementing it for real.
+
+This design builds on the `core_services` framework introduced in
+**PR #120** (branch `feat/core-services-execute-source-application`).
+
+---
+
+## 1. Concept
+
+A node should not sit idle. When it has spare resources (CPU, RAM, …) and is not
+serving any real/paid workloads, it can *opportunistically* run a designated
+**low-demand fallback** core service — think of it as a background/best-effort
+tenant that soaks up otherwise-wasted capacity (e.g. a batch, mining, indexing,
+or reputation-crunching service).
+
+Two hard rules:
+
+1. **Real workloads always preempt the fallback.** The instant a real `execute`
+   request arrives (a `StartService` on the gateway), or resources cross the
+   configured thresholds, the fallback must be stopped/paused so the paid
+   workload gets the capacity.
+2. **Per-resource thresholds gate it.** For each resource the node tracks (CPU,
+   RAM, and any future signal), an env-var/config threshold defines the level
+   under which the fallback is allowed to run. If *any* resource is above its
+   threshold, the fallback does not start (and a running one is stopped).
+
+Like the other core services, it is referenced by service id (content hash) in
+the top-level `core_services:` list — never by URL — so trust and resolution
+reuse the exact framework from PR #120.
+
+### Proposed role name
+
+```
+low-demand-fallback
+```
+
+Added as `LOW_DEMAND_FALLBACK = "low-demand-fallback"` alongside
+`SOURCE_APPLICATION` in `src/core_services/__init__.py`.
+
+---
+
+## 2. Where things live in the codebase (grounding)
+
+Everything below is a real file:line found while researching, so the integration
+is concrete rather than hand-wavy.
+
+### 2.1 The serve loop / daemon entrypoint (where the scheduler goes)
+
+- `src/serve.py:12` — `serve()` starts the manager on a daemon thread
+  (`threading.Thread(target=manager_thread, daemon=True).start()`) and then runs
+  the gRPC gateway server.
+- `src/manager/maintain.py:250` — `manager_thread()` is the node's background
+  loop. Its `while True:` at `src/manager/maintain.py:269` already runs periodic
+  maintenance (`maintain_vmachines`, `maintain_clients`, `peer_deposits`, …) and
+  sleeps `MANAGER_ITERATION_TIME` seconds (`src/manager/maintain.py:288`).
+
+  **This is the natural home for the fallback scheduler tick.** A single call
+  such as `run_fallback_once()` added inside that loop (guarded, best-effort)
+  gives us a periodic idle-check without spawning another thread. See the
+  integration TODO in `src/core_services/low_demand.py`.
+
+### 2.2 Resource signals the node already measures
+
+- **RAM:** `src/manager/resources.py` — `IOBigData` (singleton) tracks the RAM
+  pool. `IOBigData().snapshot()` (`src/manager/resources.py:99`) returns
+  `system_available`, `pool_available`, `ram_locked`, `effective_available`.
+  `psutil.virtual_memory()` is used directly there too. `get_ram_avaliable()`
+  (`resources.py:76`) = pool minus locked. This is the RAM signal to compare
+  against the RAM threshold.
+- **CPU:** `psutil.cpu_percent(...)` is already used in several places:
+  `src/manager/power.py:48` (`get_system_metrics` returns `cpu_percent` and
+  `memory_usage` = `memory.percent`), and in the cost functions
+  (`src/utils/cost_functions/generate_estimated_cost.py:32`,
+  `src/utils/cost_functions/execution_cost.py:145`). CPU availability is
+  computed as `100 - psutil.cpu_percent(...)`.
+- **"How busy is the node" (running workloads):**
+  `SQLConnection().get_all_internal_containers_ids()`
+  (`src/database/sql_connection.py:479`) lists running internal instances;
+  `internal_instance_exists(id)` (`sql_connection.py:513`) checks one.
+
+  Note `power.py`'s `get_system_metrics()` is a ready-made single call that
+  returns both `cpu_percent` and `memory_usage` (percent). We could reuse it, but
+  it does a blocking `psutil.cpu_percent(interval=1)`; for a poll loop we may
+  prefer the non-blocking form. **(open question 4)**
+
+### 2.3 Starting the fallback (launch path)
+
+- `src/core_services/runtime.py` —
+  `ensure_core_service_running(service_id, *, launch=True)`
+  resolves an already-running instance (`find_running_endpoint`), else
+  best-effort downloads via the source-application, else launches via the
+  canonical `nodo execute` path (`src/commands/execute.py:116`). Fully
+  defensive, never raises. **The fallback launches through exactly this.**
+
+### 2.4 Stopping the fallback (preemption path)
+
+- `src/manager/manager.py:531` — `stop_instance(token: str)` is the canonical
+  stop. It handles internal and external instances, refunds gas, purges DB, and
+  calls `kill(vmachine_id=...)`.
+- Gateway exposes it: `Gateway.StopService` at `src/gateway/gateway.py:31` calls
+  `stop_instance(token=token)`.
+
+  To stop the fallback we need its **token/instance id**. `find_running_endpoint`
+  (runtime.py) currently returns only the endpoint; to preempt we also need the
+  instance token so we can call `stop_instance`. **(open question 2 — we propose
+  adding a small `find_running_instance(service_id) -> (token, endpoint)` helper,
+  or having the scheduler track the token it launched.)**
+
+### 2.5 The preemption trigger (a real request arriving)
+
+- `src/gateway/gateway.py:28` — `Gateway.StartService` is *the* entrypoint for
+  an incoming (real) execute request; it delegates to `StartServiceIterable`.
+
+  This is the signal that must preempt the fallback. Options (open question 3):
+  - **(a) Reactive:** hook `StartService` so that, before/at the start of a real
+    launch, it stops any running fallback instance. Lowest-latency preemption.
+  - **(b) Polled:** the scheduler in `manager_thread` notices a new real
+    internal instance (via `get_all_internal_containers_ids()` growing, or a
+    dedicated "real workload present" flag) and stops the fallback on the next
+    tick (≤ `MANAGER_ITERATION_TIME`, default 10s). Simpler, but up to one tick
+    of contention.
+
+  The scaffold assumes (b) for the first cut (no gateway edits, purely additive)
+  and leaves (a) as the low-latency upgrade for Josemi to choose.
+
+### 2.6 Config / env-var convention
+
+- `src/utils/config.py:156` — `ConfigManager.get("a.b.C")` reads nested YAML via
+  dot notation, and also resolves a bare top-level key by scanning sections.
+  Values come from `config.yaml` (loaded from `config.example.yaml`).
+  **Note:** there is *no* `os.environ` override inside `get()` today — "env var"
+  in the spec maps to **config keys** in `config.yaml` (the node's env), which is
+  how every other tunable works (e.g. `packer.PACKER_MEMORY_SIZE_FACTOR`,
+  `timing.MANAGER_ITERATION_TIME`). We follow that convention: a `low_demand:`
+  section with per-resource threshold keys. **(open question 5: if literal
+  process env-var overrides are wanted, that's a separate ConfigManager change.)**
+
+---
+
+## 3. Proposed config block
+
+Added to `config.example.yaml` next to the other tunables, plus the
+`core_services` entry:
+
+```yaml
+core_services:
+  - name: "source-application"
+    id: "<SET_ME>"
+  - name: "packer"
+    id: "<SET_ME>"
+  - name: "low-demand-fallback"      # NEW
+    id: "<SET_ME>"
+
+low_demand:
+  ENABLED: false            # master switch; opportunistic fallback is OFF by default
+  POLL_INTERVAL: 30         # seconds between idle checks (independent of MANAGER_ITERATION_TIME)
+  CPU_MAX_PERCENT: 40       # run only when system CPU usage is <= this
+  MEM_MAX_PERCENT: 60       # run only when system memory usage is <= this
+  # Future per-resource thresholds go here (e.g. GPU_MAX_PERCENT, DISK_MAX_PERCENT).
+```
+
+Rationale for defaults: `ENABLED: false` so nothing changes for existing nodes
+until an operator opts in; conservative CPU/MEM ceilings so a real workload has
+clear headroom.
+
+---
+
+## 4. Scheduler lifecycle (proposed)
+
+Per tick (every `low_demand.POLL_INTERVAL`, driven from `manager_thread`):
+
+```
+if not low_demand.ENABLED:            -> do nothing
+if get_core_service_id("low-demand-fallback") is None:  -> do nothing (fail closed)
+
+busy = a real workload is present  (open question 3: reactive hook vs. polled)
+under_threshold = resources_below_threshold()   # CPU% <= CPU_MAX and MEM% <= MEM_MAX and ...
+
+if under_threshold and not busy:
+    ensure_core_service_running(id)   # launch/resume the fallback (idempotent)
+else:
+    stop the running fallback instance (preempt), if any
+```
+
+Key properties:
+
+- **Idempotent start:** `ensure_core_service_running` returns the endpoint of an
+  already-running instance without relaunching, so calling it every tick is safe.
+- **Preemption:** any of {resources over threshold, a real request present}
+  triggers stopping the fallback. With the reactive option (2.5a) a real
+  `StartService` also stops it immediately, not just on the next tick.
+- **Defensive:** the whole tick is wrapped so a failure never disturbs the
+  manager loop (matches the tone of the rest of `core_services`).
+
+---
+
+## 5. Open questions for Josemi (decisions needed)
+
+1. **Exact resource signals & thresholds.** Confirm CPU% + MEM% are the right
+   first cut, and whether the RAM threshold should compare against
+   `psutil.virtual_memory().percent` (simple, system-wide) or the node's own
+   `IOBigData().get_ram_avaliable()` pool (accounts for VM reservations). The
+   scaffold uses the simple system-wide `psutil` percent and TODOs the pool
+   variant.
+2. **Stop vs. pause.** Should preemption fully `stop_instance()` the fallback
+   (losing in-flight work, freeing all resources) or *pause/suspend* it (keep
+   state, resume cheaply)? The node currently only has `stop_instance`
+   (`manager.py:531`) + `kill`; there is no suspend primitive. If pause is
+   required we need a new virtualizer capability. Also: to stop it we need the
+   fallback's **instance token** — propose a `find_running_instance(service_id)`
+   helper in `runtime.py` (open item 2.4).
+3. **How to detect "a real request arrived."** Reactive hook into
+   `Gateway.StartService` (`gateway.py:28`, lowest latency) vs. polled detection
+   in `manager_thread` (simplest, ≤1 tick latency). Which do you want first?
+   And how do we distinguish a *real* request from the fallback's own launch
+   (which also goes through the execute path)? Proposal: tag the fallback
+   instance (e.g. a known `instance_name`/father id) so the scheduler and the
+   preemption check ignore it when counting "real" workloads.
+4. **CPU sampling cost.** `psutil.cpu_percent(interval=1)` blocks 1s
+   (as in `power.py:48`). For a poll loop we'd prefer the non-blocking
+   `cpu_percent(interval=None)` (needs a warm-up call). Confirm acceptable.
+5. **Config vs. literal env vars.** `ConfigManager.get()` has no process-env
+   override today; the spec's "environment-variable threshold" is implemented as
+   `config.yaml` keys under `low_demand:` (consistent with every other tunable).
+   If you want real `LOW_DEMAND_CPU_MAX_PERCENT`-style OS env overrides, that's a
+   separate ConfigManager enhancement — say the word.
+6. **GPU / other resources.** Out of scope for the first cut; the
+   `resources_below_threshold()` design is a per-resource AND-of-checks so adding
+   `GPU_MAX_PERCENT` later is a localized change.
+7. **Where to drive the tick.** Reuse `manager_thread` (`maintain.py:269`, no new
+   thread — preferred) vs. a dedicated scheduler thread started in `serve.py:12`.
+   Scaffold assumes the former.
+
+---
+
+## 6. What ships in this PR (scaffold only)
+
+- `LOW_DEMAND_FALLBACK` role constant in `src/core_services/__init__.py`.
+- `low-demand-fallback` entry (`<SET_ME>`) + a documented `low_demand:` block in
+  `config.example.yaml`.
+- `src/core_services/low_demand.py` — skeleton: `resources_below_threshold()`,
+  `should_run_fallback()`, `run_fallback_once()`. Heavily documented, never
+  raises, **not wired into the serve loop** (integration TODO points at
+  `src/manager/maintain.py:269`).
+- `tests/test_low_demand.py` — unit tests with mocked resource readings and a
+  mocked `ensure_core_service_running` (no real launch/network).

--- a/docs/design/low-demand-fallback.md
+++ b/docs/design/low-demand-fallback.md
@@ -1,10 +1,12 @@
-# Low-Demand Fallback Core Service — Design (WIP / DRAFT)
+# Low-Demand Fallback Core Service — Design
 
-Status: **proposal for Josemi's sign-off.** This document specifies a new core
-service and its node-side scheduler. The scaffold that accompanies it
-(`src/core_services/low_demand.py`, config entries, tests) is intentionally
-**not wired into the serve loop** — the exact scheduling/preemption mechanism is
-the thing we want to agree on before implementing it for real.
+Status: **decisions FINAL (Josemi signed off); scheduler wired.** This document
+specifies a new core service and its node-side scheduler. The three previously-open
+design questions (resource signals, stop-vs-pause, request detection) are now
+resolved — see §5. The scheduler is **wired into the manager loop**
+(`src/manager/maintain.py:manager_thread`) and is a no-op unless
+`low_demand.ENABLED` is set, so existing nodes are unaffected until an operator opts
+in.
 
 This design builds on the `core_services` framework introduced in
 **PR #120** (branch `feat/core-services-execute-source-application`).
@@ -60,10 +62,10 @@ is concrete rather than hand-wavy.
   maintenance (`maintain_vmachines`, `maintain_clients`, `peer_deposits`, …) and
   sleeps `MANAGER_ITERATION_TIME` seconds (`src/manager/maintain.py:288`).
 
-  **This is the natural home for the fallback scheduler tick.** A single call
-  such as `run_fallback_once()` added inside that loop (guarded, best-effort)
-  gives us a periodic idle-check without spawning another thread. See the
-  integration TODO in `src/core_services/low_demand.py`.
+  **This is the home for the fallback scheduler tick (now wired).** A single
+  guarded `scheduler_tick()` call is added inside that loop; it self-gates to
+  `low_demand.POLL_INTERVAL` and gives a periodic idle-check without spawning
+  another thread.
 
 ### 2.2 Resource signals the node already measures
 
@@ -117,17 +119,16 @@ is concrete rather than hand-wavy.
 - `src/gateway/gateway.py:28` — `Gateway.StartService` is *the* entrypoint for
   an incoming (real) execute request; it delegates to `StartServiceIterable`.
 
-  This is the signal that must preempt the fallback. Options (open question 3):
+  This is the signal that must preempt the fallback. Two options were considered:
   - **(a) Reactive:** hook `StartService` so that, before/at the start of a real
     launch, it stops any running fallback instance. Lowest-latency preemption.
   - **(b) Polled:** the scheduler in `manager_thread` notices a new real
-    internal instance (via `get_all_internal_containers_ids()` growing, or a
-    dedicated "real workload present" flag) and stops the fallback on the next
-    tick (≤ `MANAGER_ITERATION_TIME`, default 10s). Simpler, but up to one tick
-    of contention.
+    internal instance (via `get_all_internal_containers_ids()` growing) and stops
+    the fallback on the next poll (≤ `POLL_INTERVAL`). Simpler, purely additive.
 
-  The scaffold assumes (b) for the first cut (no gateway edits, purely additive)
-  and leaves (a) as the low-latency upgrade for Josemi to choose.
+  **Decision (§5.3, FINAL): (b) polled.** No gateway edits; the fallback's own
+  instance is excluded from the "real workload" count via its recorded launch
+  token. (a) remains a possible low-latency upgrade later.
 
 ### 2.6 Config / env-var convention
 
@@ -200,53 +201,70 @@ Key properties:
 
 ---
 
-## 5. Open questions for Josemi (decisions needed)
+## 5. Resolved decisions (Josemi — FINAL)
 
-1. **Exact resource signals & thresholds.** Confirm CPU% + MEM% are the right
-   first cut, and whether the RAM threshold should compare against
-   `psutil.virtual_memory().percent` (simple, system-wide) or the node's own
-   `IOBigData().get_ram_avaliable()` pool (accounts for VM reservations). The
-   scaffold uses the simple system-wide `psutil` percent and TODOs the pool
-   variant.
-2. **Stop vs. pause.** Should preemption fully `stop_instance()` the fallback
-   (losing in-flight work, freeing all resources) or *pause/suspend* it (keep
-   state, resume cheaply)? The node currently only has `stop_instance`
-   (`manager.py:531`) + `kill`; there is no suspend primitive. If pause is
-   required we need a new virtualizer capability. Also: to stop it we need the
-   fallback's **instance token** — propose a `find_running_instance(service_id)`
-   helper in `runtime.py` (open item 2.4).
-3. **How to detect "a real request arrived."** Reactive hook into
-   `Gateway.StartService` (`gateway.py:28`, lowest latency) vs. polled detection
-   in `manager_thread` (simplest, ≤1 tick latency). Which do you want first?
-   And how do we distinguish a *real* request from the fallback's own launch
-   (which also goes through the execute path)? Proposal: tag the fallback
-   instance (e.g. a known `instance_name`/father id) so the scheduler and the
-   preemption check ignore it when counting "real" workloads.
-4. **CPU sampling cost.** `psutil.cpu_percent(interval=1)` blocks 1s
-   (as in `power.py:48`). For a poll loop we'd prefer the non-blocking
-   `cpu_percent(interval=None)` (needs a warm-up call). Confirm acceptable.
-5. **Config vs. literal env vars.** `ConfigManager.get()` has no process-env
-   override today; the spec's "environment-variable threshold" is implemented as
-   `config.yaml` keys under `low_demand:` (consistent with every other tunable).
-   If you want real `LOW_DEMAND_CPU_MAX_PERCENT`-style OS env overrides, that's a
-   separate ConfigManager enhancement — say the word.
+The three design questions below were put to maintainer Josemi and are now
+**decided and implemented**. Items 4–7 are recorded for completeness.
+
+1. **Resource signals & thresholds — FINAL: CPU% + RAM% + hysteresis, delegated
+   to us.** Poll every `POLL_INTERVAL` (default 30s) *inside the existing
+   `manager_thread` loop* (no new thread). Gate the low-demand start on BOTH:
+   - **CPU:** `psutil.cpu_percent` `<=` `CPU_MAX_PERCENT` (default 40), and
+   - **RAM:** the node's `IOBigData` reservation accounting
+     (`snapshot()['effective_available'] > 0`, pool minus VM locks) **cross-checked
+     with** `psutil.virtual_memory().percent <= MEM_MAX_PERCENT` (default 60).
+
+   Plus **hysteresis**: require `LOW_DEMAND_CONSECUTIVE_POLLS` (default 3)
+   consecutive below-threshold, idle polls before starting, to avoid flapping.
+   Implemented in `resources_below_threshold()` / `_iobigdata_has_headroom()` and
+   the hysteresis counter in `scheduler_tick()`.
+
+2. **Stop vs. pause — FINAL: ALWAYS STOP.** There is no suspend/pause primitive in
+   Celaut today. When a real `execute` request arrives, or resources exceed a
+   threshold, the low-demand instance is **stopped immediately** via
+   `stop_instance()` (`manager.py:531`) — never paused/suspended. To get the
+   instance's stop token we added `find_running_instance(service_id) -> (token,
+   endpoint)` to `runtime.py`, and the scheduler also remembers the token it
+   launched. Implemented in `_stop_running_fallback()`.
+
+3. **Request detection — FINAL: POLLED, not reactive.** Pending/running real
+   `execute` requests are detected by polling node state each tick
+   (`SQLConnection().get_all_internal_containers_ids()`); **no** gateway
+   event hooks/callbacks are added. The fallback's own instance is excluded from
+   the count via the recorded launch token so it never preempts itself.
+   Implemented in `_real_workload_present()`.
+
+### Recorded for completeness (not blocking)
+
+4. **CPU sampling cost.** The poll uses the non-blocking
+   `psutil.cpu_percent(interval=None)` form (cheap per tick; the blocking
+   `interval=1` form in `power.py:48` is avoided).
+5. **Config vs. literal env vars.** Thresholds live as `config.yaml` keys under
+   `low_demand:` (consistent with every other tunable). Literal OS-env overrides
+   would be a separate `ConfigManager` change and are out of scope.
 6. **GPU / other resources.** Out of scope for the first cut; the
    `resources_below_threshold()` design is a per-resource AND-of-checks so adding
    `GPU_MAX_PERCENT` later is a localized change.
-7. **Where to drive the tick.** Reuse `manager_thread` (`maintain.py:269`, no new
-   thread — preferred) vs. a dedicated scheduler thread started in `serve.py:12`.
-   Scaffold assumes the former.
+7. **Where to drive the tick — FINAL: reuse `manager_thread`.** The tick is a
+   single guarded `scheduler_tick()` call in the existing loop
+   (`maintain.py`), which self-gates to `POLL_INTERVAL`. No dedicated thread.
 
 ---
 
-## 6. What ships in this PR (scaffold only)
+## 6. What ships in this PR
 
 - `LOW_DEMAND_FALLBACK` role constant in `src/core_services/__init__.py`.
 - `low-demand-fallback` entry (`<SET_ME>`) + a documented `low_demand:` block in
-  `config.example.yaml`.
-- `src/core_services/low_demand.py` — skeleton: `resources_below_threshold()`,
-  `should_run_fallback()`, `run_fallback_once()`. Heavily documented, never
-  raises, **not wired into the serve loop** (integration TODO points at
-  `src/manager/maintain.py:269`).
-- `tests/test_low_demand.py` — unit tests with mocked resource readings and a
-  mocked `ensure_core_service_running` (no real launch/network).
+  `config.example.yaml`, including `LOW_DEMAND_CONSECUTIVE_POLLS`.
+- `src/core_services/low_demand.py` — `resources_below_threshold()` (CPU + RAM +
+  IOBigData cross-check), `_real_workload_present()` (polled, excludes the
+  fallback's own instance), `should_run_fallback()`, `run_fallback_once()`, and the
+  stateful `scheduler_tick()` (hysteresis + always-stop preemption + `POLL_INTERVAL`
+  cadence). Heavily documented, never raises.
+- `src/core_services/runtime.py` — `find_running_instance(service_id) -> (token,
+  endpoint)` so preemption can `stop_instance()` the fallback.
+- `src/manager/maintain.py` — a single guarded `scheduler_tick()` call wired into
+  the existing `manager_thread` loop (no new thread; no-op unless `ENABLED`).
+- `tests/test_low_demand.py` — unit tests with mocked resource readings, a mocked
+  `ensure_core_service_running`, and coverage of hysteresis start, over-threshold
+  no-start, real-request-preempts-STOP, and polled detection (no real launch/network).

--- a/src/commands/execute.py
+++ b/src/commands/execute.py
@@ -11,6 +11,7 @@ from protos import celaut_pb2, celaut_pb2_grpc, gateway_bee
 
 from src.commands.inspect import inspect as inspect_service
 from src.commands.__by_tag import get_id
+from src.core_services.source_application import acquire_service
 from src.manager.manager import get_execute_client
 from src.utils.hashing import get_configured_hash_id
 from src.utils.config import ConfigManager
@@ -118,10 +119,21 @@ def execute(
     envs: dict[str, str] | None = None,
     instance_name: str | None = None,
 ):
-    service = resolve_service_hash(service)
-    if not service:
+    resolved = resolve_service_hash(service)
+    if not resolved:
+        # The service isn't in the local registry. Before refusing, try to acquire it
+        # through the 'source-application' core service: it maps the requested service id
+        # to its published sources and downloads it via the existing download/import path.
+        # This only succeeds when a trusted source-application is configured in
+        # 'core_services'; otherwise it's a no-op and we fall through to the error below.
+        if acquire_service(service):
+            resolved = resolve_service_hash(service)
+
+    if not resolved:
         print("❌ Service not allowed.")
         return
+
+    service = resolved
 
     channel = None
     stop_event = threading.Event()

--- a/src/core_services/__init__.py
+++ b/src/core_services/__init__.py
@@ -1,0 +1,47 @@
+"""Core services: Celaut services the node treats as part of its own workflow.
+
+Core services are referenced by service id (content hash), configured under the
+top-level ``core_services`` list in ``config.yaml`` as ``{name, id}`` entries.
+They let the node bootstrap capabilities it does not ship with — for example,
+resolving and auto-downloading a service that ``nodo execute`` is asked to run
+but does not have locally (see :mod:`src.core_services.source_application`).
+"""
+
+from typing import Optional
+
+from src.utils.config import ConfigManager
+
+# Placeholder kept in ``config.example.yaml`` until a core service id is published.
+# A core service whose id is unset or still set to this value is treated as "not
+# configured" so the node fails closed instead of inventing/trusting an id.
+UNSET_PLACEHOLDER = "<SET_ME>"
+
+# Well-known core service roles (the ``name`` field of each entry).
+SOURCE_APPLICATION = "source-application"
+
+_env_manager = ConfigManager()
+
+
+def get_core_service_id(name: str) -> Optional[str]:
+    """Return the configured service id for the core service role ``name``.
+
+    Returns ``None`` when ``core_services`` is missing/empty, has no entry for
+    ``name``, or the entry's id is unset or still the ``"<SET_ME>"`` placeholder.
+    Callers must treat ``None`` as "this capability is not configured" and degrade
+    gracefully rather than fabricate an id.
+    """
+    entries = _env_manager.get("core_services", []) or []
+    if not isinstance(entries, list):
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") != name:
+            continue
+        service_id = str(entry.get("id", "") or "").strip()
+        if not service_id or service_id == UNSET_PLACEHOLDER:
+            return None
+        return service_id
+
+    return None

--- a/src/core_services/__init__.py
+++ b/src/core_services/__init__.py
@@ -18,6 +18,10 @@ UNSET_PLACEHOLDER = "<SET_ME>"
 
 # Well-known core service roles (the ``name`` field of each entry).
 SOURCE_APPLICATION = "source-application"
+# Opportunistic best-effort tenant the node runs only when it has spare capacity
+# and no real workloads; always preempted by real/paid execute requests. See
+# :mod:`src.core_services.low_demand` and ``docs/design/low-demand-fallback.md``.
+LOW_DEMAND_FALLBACK = "low-demand-fallback"
 
 _env_manager = ConfigManager()
 

--- a/src/core_services/low_demand.py
+++ b/src/core_services/low_demand.py
@@ -36,6 +36,7 @@ Status / contract
   question 5 in the design doc.
 """
 
+import time
 from typing import Optional
 
 from src.core_services import LOW_DEMAND_FALLBACK, get_core_service_id
@@ -48,6 +49,30 @@ _DEFAULT_ENABLED = False
 _DEFAULT_POLL_INTERVAL = 30
 _DEFAULT_CPU_MAX_PERCENT = 40.0
 _DEFAULT_MEM_MAX_PERCENT = 60.0
+# Hysteresis: how many consecutive below-threshold, idle polls are required before the
+# fallback is actually started, to avoid flapping on brief resource dips.
+_DEFAULT_CONSECUTIVE_POLLS = 3
+
+
+class _SchedulerState:
+    """In-memory scheduler state for the manager-loop-driven fallback tick.
+
+    Kept as a module singleton (mirrors ``ConfigManager()`` / ``IOBigData()`` usage
+    elsewhere) so the tick can carry hysteresis + the launched instance's stop token
+    across manager iterations without a new thread or persistent storage.
+    """
+
+    def __init__(self) -> None:
+        # Consecutive below-threshold, idle polls observed so far (hysteresis counter).
+        self.consecutive_below = 0
+        # Monotonic timestamp of the last tick that actually ran, or ``None`` if never.
+        self.last_tick_monotonic: Optional[float] = None
+        # Stop token of the fallback instance we launched, so we can (a) exclude it when
+        # counting "real" workloads and (b) STOP it on preemption. ``None`` if not running.
+        self.running_token: Optional[str] = None
+
+
+_state = _SchedulerState()
 
 
 def _get_float(key: str, default: float) -> float:
@@ -88,6 +113,19 @@ def poll_interval_seconds() -> int:
         return _DEFAULT_POLL_INTERVAL
 
 
+def consecutive_polls() -> int:
+    """Return the hysteresis depth (``low_demand.LOW_DEMAND_CONSECUTIVE_POLLS``).
+
+    The number of consecutive below-threshold, idle polls required before the fallback
+    is started. Never raises; falls back to the default and clamps to a minimum of 1
+    (1 == no hysteresis, start on the first clean poll).
+    """
+    try:
+        return max(1, int(_get_float("LOW_DEMAND_CONSECUTIVE_POLLS", _DEFAULT_CONSECUTIVE_POLLS)))
+    except Exception:
+        return _DEFAULT_CONSECUTIVE_POLLS
+
+
 def _current_cpu_percent() -> Optional[float]:
     """Best-effort current system CPU usage percent, or ``None`` if unavailable.
 
@@ -107,10 +145,9 @@ def _current_cpu_percent() -> Optional[float]:
 def _current_mem_percent() -> Optional[float]:
     """Best-effort current system memory usage percent, or ``None`` if unavailable.
 
-    Uses the simple system-wide ``psutil.virtual_memory().percent``. TODO (open
-    question 1): optionally compare against the node's own RAM pool via
-    ``src.manager.resources.IOBigData().get_ram_avaliable()`` /
-    ``snapshot()['effective_available']``, which accounts for VM reservations.
+    Uses the simple system-wide ``psutil.virtual_memory().percent``. This is the
+    *system-wide* half of the RAM gate; it is cross-checked against the node's own
+    reservation accounting in :func:`_iobigdata_has_headroom` (Josemi decision #1).
     Never raises.
     """
     try:
@@ -121,6 +158,28 @@ def _current_mem_percent() -> Optional[float]:
         return None
 
 
+def _iobigdata_has_headroom() -> bool:
+    """Return ``True`` iff the node's own RAM pool still has positive availability.
+
+    RAM gate, part 2 (Josemi decision #1): cross-check the system-wide
+    ``psutil.virtual_memory().percent`` against the node's ``IOBigData`` reservation
+    accounting. Even when the system-wide percent looks fine, the node's pool may
+    already be fully reserved by in-flight VM locks; ``snapshot()['effective_available']``
+    (pool minus locked) captures that. We require it to be strictly positive.
+
+    Fail-closed: any error (import failure, singleton/snapshot error, missing key)
+    yields ``False`` so the fallback is not started on incomplete information. Never
+    raises.
+    """
+    try:
+        from src.manager.resources import IOBigData
+
+        snapshot = IOBigData().snapshot()
+        return int(snapshot.get("effective_available", 0)) > 0
+    except Exception:
+        return False
+
+
 def resources_below_threshold() -> bool:
     """Return ``True`` iff EVERY tracked resource is at/under its configured threshold.
 
@@ -128,6 +187,14 @@ def resources_below_threshold() -> bool:
     thresholds and compares them against the current system readings. The design is
     an **AND of per-resource checks**, so adding a new resource later (e.g. GPU) is
     a localized change: add its threshold + reading and ``and`` it in here.
+
+    Gates (Josemi decision #1 — FINAL):
+        * **CPU:** ``psutil.cpu_percent`` <= ``CPU_MAX_PERCENT``.
+        * **RAM:** BOTH ``psutil.virtual_memory().percent`` <= ``MEM_MAX_PERCENT``
+          AND the node's own ``IOBigData`` pool has positive ``effective_available``
+          (:func:`_iobigdata_has_headroom`) — the system-wide percent is cross-checked
+          against the node's reservation accounting so a fully-reserved pool blocks the
+          start even when system RAM looks free.
 
     Fail-closed: if a resource reading is unavailable (``None``), that resource is
     treated as *not* satisfying its threshold, so the fallback is not started on
@@ -143,30 +210,39 @@ def resources_below_threshold() -> bool:
     if cpu is None or mem is None:
         return False
 
-    return cpu <= cpu_max and mem <= mem_max
+    if cpu > cpu_max or mem > mem_max:
+        return False
+
+    # RAM cross-check against the node's own reservation accounting.
+    if not _iobigdata_has_headroom():
+        return False
+
+    return True
 
 
 def _real_workload_present() -> bool:
-    """Best-effort: is the node currently serving a real workload?
+    """Best-effort: is the node currently serving a *real* workload?
 
-    Preemption trigger. First-cut (polled) implementation counts running internal
-    instances via ``SQLConnection().get_all_internal_containers_ids()``
-    (``src/database/sql_connection.py:479``). Any real workload means the fallback
-    must not run.
+    Preemption trigger, **polled** (Josemi decision #3 — FINAL): count running
+    internal instances via ``SQLConnection().get_all_internal_containers_ids()``
+    (``src/database/sql_connection.py:479``) on each tick. No gateway hooks/callbacks.
+    Any real workload means the fallback must not run.
 
-    TODO (open question 3): (a) this counts the fallback's OWN instance too — tag
-    the fallback instance (known ``instance_name``/father id) and exclude it here;
-    (b) the lower-latency alternative is a reactive hook in
-    ``Gateway.StartService`` (``src/gateway/gateway.py:28``) that stops the
-    fallback immediately when a real request arrives, rather than waiting for the
-    next poll tick. Never raises; on error assume "busy" (fail closed).
+    The fallback's OWN instance is excluded: when we launch it we record its stop
+    token in :data:`_state.running_token` (see :func:`_start_fallback`), and that
+    token is filtered out here so the fallback never counts itself as a real
+    workload (which would otherwise make it preempt itself and flap).
+
+    Never raises; on error assume "busy" (fail closed) so we never contend with a
+    possible real workload.
     """
     try:
         from src.database.sql_connection import SQLConnection
 
         ids = SQLConnection().get_all_internal_containers_ids() or []
-        # TODO: exclude the fallback's own instance id/token once it is tagged.
-        return len(ids) > 0
+        own = _state.running_token
+        real = [i for i in ids if i != own]
+        return len(real) > 0
     except Exception:
         # Unknown -> assume busy so we never contend with a possible real workload.
         return True
@@ -199,41 +275,21 @@ def should_run_fallback() -> bool:
 
 
 def run_fallback_once() -> Optional[str]:
-    """One scheduler tick: start the fallback if it should run; report its endpoint.
+    """Idempotently (re)launch the fallback if it should run; report its endpoint.
 
     Behaviour:
         * If :func:`should_run_fallback` is ``True``, best-effort launch/resume the
           fallback via
           :func:`src.core_services.runtime.ensure_core_service_running`
           (idempotent — it returns an already-running instance's endpoint without
-          relaunching), and return that endpoint (or ``None`` if it couldn't be
-          brought up).
+          relaunching), record the launched instance's stop token for preemption,
+          and return that endpoint (or ``None`` if it couldn't be brought up).
         * Otherwise return ``None`` and do nothing here.
 
-    **Preemption is NOT yet implemented in this scaffold.** When
-    :func:`should_run_fallback` is false and a fallback instance is running, a real
-    implementation must STOP it via ``stop_instance(token=...)``
-    (``src/manager/manager.py:531``). That needs the fallback's instance token,
-    which ``ensure_core_service_running``/``find_running_endpoint`` do not return
-    today — see open question 2 (propose a ``find_running_instance(service_id)``
-    helper in ``runtime.py``, or have the scheduler remember the token it launched).
-
-    INTEGRATION TODO (not wired yet — needs Josemi's sign-off):
-        Drive this from the manager loop in
-        ``src/manager/maintain.py`` — inside ``manager_thread``'s ``while True:``
-        at ``src/manager/maintain.py:269`` (which already sleeps
-        ``MANAGER_ITERATION_TIME`` at line 288). Add a guarded call roughly like::
-
-            from src.core_services.low_demand import run_fallback_once
-            try:
-                run_fallback_once()
-            except Exception:
-                pass
-
-        (respecting ``poll_interval_seconds()`` cadence), plus the preemption
-        branch once the stop path (open question 2) is decided. Reusing the
-        existing manager thread avoids spawning another thread; alternatively a
-        dedicated scheduler thread could be started in ``src/serve.py:12``.
+    This is the *stateless launch primitive*. The hysteresis + preemption policy and
+    the ``POLL_INTERVAL`` cadence live in :func:`scheduler_tick`, which is what the
+    manager loop drives; ``run_fallback_once`` is the "make it running now" building
+    block it and the tests use.
 
     Never raises.
     """
@@ -247,6 +303,128 @@ def run_fallback_once() -> Optional[str]:
 
         from src.core_services.runtime import ensure_core_service_running
 
-        return ensure_core_service_running(service_id, launch=True)
+        endpoint = ensure_core_service_running(service_id, launch=True)
+        # Record the running instance's stop token so the tick can (a) exclude it from
+        # "real workload" counting and (b) STOP it on preemption. Best-effort.
+        _record_running_token(service_id)
+        return endpoint
     except Exception:
         return None
+
+
+# --- Scheduler tick (wired into src/manager/maintain.py:manager_thread) ------------
+
+
+def _reset_hysteresis() -> None:
+    """Reset the consecutive-below-threshold counter (call on any preemption/abort)."""
+    _state.consecutive_below = 0
+
+
+def _record_running_token(service_id: str) -> None:
+    """Best-effort: remember the running fallback instance's stop token in ``_state``.
+
+    Uses :func:`src.core_services.runtime.find_running_instance`. Never raises; on
+    failure it simply leaves the previously known token in place.
+    """
+    try:
+        from src.core_services.runtime import find_running_instance
+
+        info = find_running_instance(service_id)
+        if info and info[0]:
+            _state.running_token = info[0]
+    except Exception:
+        pass
+
+
+def _stop_running_fallback() -> None:
+    """STOP (never pause) the running fallback instance, if any (Josemi decision #2).
+
+    There is no suspend/pause primitive in Celaut, so preemption is always a full
+    ``stop_instance(token=...)`` (``src/manager/manager.py:531``). Uses the token we
+    recorded at launch; if we don't have one, best-effort discovers a running fallback
+    instance via :func:`src.core_services.runtime.find_running_instance`. Never raises.
+    """
+    token = _state.running_token
+    if not token:
+        try:
+            service_id = get_core_service_id(LOW_DEMAND_FALLBACK)
+            if service_id:
+                from src.core_services.runtime import find_running_instance
+
+                info = find_running_instance(service_id)
+                if info and info[0]:
+                    token = info[0]
+        except Exception:
+            token = None
+
+    if not token:
+        _state.running_token = None
+        return
+
+    try:
+        from src.manager.manager import stop_instance
+
+        stop_instance(token=token)
+    except Exception:
+        # Stop failed (no daemon, already gone, …) — nothing else we can safely do.
+        pass
+    finally:
+        _state.running_token = None
+
+
+def scheduler_tick() -> None:
+    """One manager-loop iteration of the opportunistic fallback scheduler.
+
+    Called every ``manager_thread`` iteration (``src/manager/maintain.py``); it
+    self-gates to the configured ``POLL_INTERVAL`` cadence so calling it more often
+    than that is a cheap no-op. Implements the three FINAL decisions:
+
+    #1 (resource signals): start only after
+       :data:`consecutive_polls` consecutive polls with
+       :func:`resources_below_threshold` true (CPU% + system RAM% + IOBigData pool
+       headroom) AND no real workload — hysteresis to avoid flapping.
+    #2 (stop vs pause): preemption ALWAYS STOPS via :func:`_stop_running_fallback`
+       (there is no pause primitive).
+    #3 (request detection): POLLED — :func:`_real_workload_present` reads node state
+       each tick; no gateway hooks.
+
+    Fully defensive: any failure is swallowed so the manager loop is never disturbed.
+    Never raises.
+    """
+    try:
+        if not is_enabled():
+            return
+
+        # Cadence gate: only do real work every POLL_INTERVAL seconds, independent of
+        # the (faster) MANAGER_ITERATION_TIME the manager loop ticks at.
+        now = time.monotonic()
+        last = _state.last_tick_monotonic
+        if last is not None and (now - last) < poll_interval_seconds():
+            return
+        _state.last_tick_monotonic = now
+
+        # No configured id -> nothing to run; make sure nothing lingers and reset.
+        if get_core_service_id(LOW_DEMAND_FALLBACK) is None:
+            _reset_hysteresis()
+            _stop_running_fallback()
+            return
+
+        busy = _real_workload_present()
+        under_threshold = resources_below_threshold()
+
+        # Preemption: a real workload OR resources over threshold => STOP immediately
+        # and reset the hysteresis counter (decisions #2 + #3).
+        if busy or not under_threshold:
+            _reset_hysteresis()
+            _stop_running_fallback()
+            return
+
+        # Idle + under threshold: require N consecutive clean polls before starting.
+        _state.consecutive_below += 1
+        if _state.consecutive_below < consecutive_polls():
+            return
+
+        # Hysteresis satisfied — (idempotently) ensure the fallback is running.
+        run_fallback_once()
+    except Exception:
+        return

--- a/src/core_services/low_demand.py
+++ b/src/core_services/low_demand.py
@@ -1,0 +1,252 @@
+"""Opportunistic **low-demand fallback** scheduler (WIP scaffold — DRAFT).
+
+Concept
+-------
+A node should not sit idle. When it has spare resources (CPU, RAM, …) and is not
+serving any real/paid workloads, it can *opportunistically* run a designated
+``low-demand-fallback`` core service — a best-effort background tenant that soaks
+up otherwise-wasted capacity. Two hard rules:
+
+1. **Real workloads always preempt the fallback.** The instant a real ``execute``
+   request arrives, or resources cross the configured thresholds, the fallback is
+   stopped so the paid workload gets the capacity.
+2. **Per-resource thresholds gate it.** Each tracked resource (CPU, RAM, and any
+   future signal) has a config threshold under which the fallback may run. If any
+   resource is above its threshold, the fallback does not start (and a running one
+   is stopped).
+
+Like the other core services, the fallback is referenced by service id in the
+top-level ``core_services`` list (role name :data:`LOW_DEMAND_FALLBACK`) and
+launched through :func:`src.core_services.runtime.ensure_core_service_running`,
+reusing the exact framework from PR #120.
+
+Status / contract
+-----------------
+* **This module is scaffold only and is NOT wired into the serve loop yet.** The
+  exact scheduling/preemption mechanism needs sign-off. See the integration TODO
+  in :func:`run_fallback_once` and ``docs/design/low-demand-fallback.md``.
+* **Nothing here ever raises into the caller.** Every read (config, resource
+  sampling) and every action (launch) is wrapped defensively and degrades to a
+  safe default (``False`` / no-op). This matches the fail-closed tone of the rest
+  of :mod:`src.core_services`.
+* "Environment-variable threshold" from the spec maps to **config keys** under the
+  ``low_demand:`` section of ``config.yaml`` (the node's env), consistent with
+  every other tunable (e.g. ``timing.MANAGER_ITERATION_TIME``). There is no
+  process-``os.environ`` override in :class:`ConfigManager` today; see open
+  question 5 in the design doc.
+"""
+
+from typing import Optional
+
+from src.core_services import LOW_DEMAND_FALLBACK, get_core_service_id
+from src.utils.config import ConfigManager
+
+_env_manager = ConfigManager()
+
+# --- Config defaults (mirrored in config.example.yaml's ``low_demand:`` block) ---
+_DEFAULT_ENABLED = False
+_DEFAULT_POLL_INTERVAL = 30
+_DEFAULT_CPU_MAX_PERCENT = 40.0
+_DEFAULT_MEM_MAX_PERCENT = 60.0
+
+
+def _get_float(key: str, default: float) -> float:
+    """Read ``low_demand.<key>`` as a float, falling back to ``default``.
+
+    Never raises: a missing key, wrong type, or unparseable value yields
+    ``default`` so the scheduler always has usable thresholds.
+    """
+    try:
+        value = _env_manager.get(f"low_demand.{key}", default)
+        if value is None:
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def is_enabled() -> bool:
+    """Return whether the opportunistic fallback is switched on (``low_demand.ENABLED``).
+
+    Defaults to ``False`` (opt-in) and never raises.
+    """
+    try:
+        return bool(_env_manager.get("low_demand.ENABLED", _DEFAULT_ENABLED))
+    except Exception:
+        return _DEFAULT_ENABLED
+
+
+def poll_interval_seconds() -> int:
+    """Return the idle-check cadence in seconds (``low_demand.POLL_INTERVAL``).
+
+    Used by the (future) serve-loop integration to decide how often to tick.
+    Never raises; falls back to the default and clamps to a sane minimum of 1s.
+    """
+    try:
+        return max(1, int(_get_float("POLL_INTERVAL", _DEFAULT_POLL_INTERVAL)))
+    except Exception:
+        return _DEFAULT_POLL_INTERVAL
+
+
+def _current_cpu_percent() -> Optional[float]:
+    """Best-effort current system CPU usage percent, or ``None`` if unavailable.
+
+    Uses the non-blocking ``psutil.cpu_percent(interval=None)`` form (unlike
+    ``power.py``'s blocking ``interval=1``) so a poll tick stays cheap; see open
+    question 4 in the design doc about the warm-up-call caveat of the non-blocking
+    form. Never raises.
+    """
+    try:
+        import psutil
+
+        return float(psutil.cpu_percent(interval=None))
+    except Exception:
+        return None
+
+
+def _current_mem_percent() -> Optional[float]:
+    """Best-effort current system memory usage percent, or ``None`` if unavailable.
+
+    Uses the simple system-wide ``psutil.virtual_memory().percent``. TODO (open
+    question 1): optionally compare against the node's own RAM pool via
+    ``src.manager.resources.IOBigData().get_ram_avaliable()`` /
+    ``snapshot()['effective_available']``, which accounts for VM reservations.
+    Never raises.
+    """
+    try:
+        import psutil
+
+        return float(psutil.virtual_memory().percent)
+    except Exception:
+        return None
+
+
+def resources_below_threshold() -> bool:
+    """Return ``True`` iff EVERY tracked resource is at/under its configured threshold.
+
+    Reads the ``low_demand.CPU_MAX_PERCENT`` / ``low_demand.MEM_MAX_PERCENT``
+    thresholds and compares them against the current system readings. The design is
+    an **AND of per-resource checks**, so adding a new resource later (e.g. GPU) is
+    a localized change: add its threshold + reading and ``and`` it in here.
+
+    Fail-closed: if a resource reading is unavailable (``None``), that resource is
+    treated as *not* satisfying its threshold, so the fallback is not started on
+    incomplete information. Never raises.
+    """
+    cpu_max = _get_float("CPU_MAX_PERCENT", _DEFAULT_CPU_MAX_PERCENT)
+    mem_max = _get_float("MEM_MAX_PERCENT", _DEFAULT_MEM_MAX_PERCENT)
+
+    cpu = _current_cpu_percent()
+    mem = _current_mem_percent()
+
+    # Missing reading -> fail closed (do not run the fallback).
+    if cpu is None or mem is None:
+        return False
+
+    return cpu <= cpu_max and mem <= mem_max
+
+
+def _real_workload_present() -> bool:
+    """Best-effort: is the node currently serving a real workload?
+
+    Preemption trigger. First-cut (polled) implementation counts running internal
+    instances via ``SQLConnection().get_all_internal_containers_ids()``
+    (``src/database/sql_connection.py:479``). Any real workload means the fallback
+    must not run.
+
+    TODO (open question 3): (a) this counts the fallback's OWN instance too — tag
+    the fallback instance (known ``instance_name``/father id) and exclude it here;
+    (b) the lower-latency alternative is a reactive hook in
+    ``Gateway.StartService`` (``src/gateway/gateway.py:28``) that stops the
+    fallback immediately when a real request arrives, rather than waiting for the
+    next poll tick. Never raises; on error assume "busy" (fail closed).
+    """
+    try:
+        from src.database.sql_connection import SQLConnection
+
+        ids = SQLConnection().get_all_internal_containers_ids() or []
+        # TODO: exclude the fallback's own instance id/token once it is tagged.
+        return len(ids) > 0
+    except Exception:
+        # Unknown -> assume busy so we never contend with a possible real workload.
+        return True
+
+
+def should_run_fallback() -> bool:
+    """Decide whether the fallback SHOULD be running right now.
+
+    Returns ``True`` only when ALL of:
+        * ``low_demand.ENABLED`` is true, and
+        * a non-placeholder ``low-demand-fallback`` id is configured in
+          ``core_services`` (else fail closed — never invent an id), and
+        * :func:`resources_below_threshold` is true, and
+        * no real workload is present (:func:`_real_workload_present` is false).
+
+    Never raises.
+    """
+    try:
+        if not is_enabled():
+            return False
+        if get_core_service_id(LOW_DEMAND_FALLBACK) is None:
+            return False
+        if not resources_below_threshold():
+            return False
+        if _real_workload_present():
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def run_fallback_once() -> Optional[str]:
+    """One scheduler tick: start the fallback if it should run; report its endpoint.
+
+    Behaviour:
+        * If :func:`should_run_fallback` is ``True``, best-effort launch/resume the
+          fallback via
+          :func:`src.core_services.runtime.ensure_core_service_running`
+          (idempotent — it returns an already-running instance's endpoint without
+          relaunching), and return that endpoint (or ``None`` if it couldn't be
+          brought up).
+        * Otherwise return ``None`` and do nothing here.
+
+    **Preemption is NOT yet implemented in this scaffold.** When
+    :func:`should_run_fallback` is false and a fallback instance is running, a real
+    implementation must STOP it via ``stop_instance(token=...)``
+    (``src/manager/manager.py:531``). That needs the fallback's instance token,
+    which ``ensure_core_service_running``/``find_running_endpoint`` do not return
+    today — see open question 2 (propose a ``find_running_instance(service_id)``
+    helper in ``runtime.py``, or have the scheduler remember the token it launched).
+
+    INTEGRATION TODO (not wired yet — needs Josemi's sign-off):
+        Drive this from the manager loop in
+        ``src/manager/maintain.py`` — inside ``manager_thread``'s ``while True:``
+        at ``src/manager/maintain.py:269`` (which already sleeps
+        ``MANAGER_ITERATION_TIME`` at line 288). Add a guarded call roughly like::
+
+            from src.core_services.low_demand import run_fallback_once
+            try:
+                run_fallback_once()
+            except Exception:
+                pass
+
+        (respecting ``poll_interval_seconds()`` cadence), plus the preemption
+        branch once the stop path (open question 2) is decided. Reusing the
+        existing manager thread avoids spawning another thread; alternatively a
+        dedicated scheduler thread could be started in ``src/serve.py:12``.
+
+    Never raises.
+    """
+    try:
+        if not should_run_fallback():
+            return None
+
+        service_id = get_core_service_id(LOW_DEMAND_FALLBACK)
+        if not service_id:
+            return None
+
+        from src.core_services.runtime import ensure_core_service_running
+
+        return ensure_core_service_running(service_id, launch=True)
+    except Exception:
+        return None

--- a/src/core_services/runtime.py
+++ b/src/core_services/runtime.py
@@ -25,7 +25,7 @@ Fail-closed / best-effort contract (mirrors source-application's tone):
 """
 
 import sqlite3
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from protos import celaut_pb2 as celaut
 from src.utils.config import ConfigManager
@@ -140,7 +140,9 @@ def find_running_instance(service_id: str) -> Optional[Tuple[str, Optional[str]]
     return None
 
 
-def ensure_core_service_running(service_id: str, *, launch: bool = True) -> Optional[str]:
+def ensure_core_service_running(
+    service_id: str, *, launch: bool = True, envs: Optional[Dict[str, str]] = None
+) -> Optional[str]:
     """Ensure a core service is running and return its endpoint, or ``None``.
 
     Resolution order:
@@ -149,7 +151,13 @@ def ensure_core_service_running(service_id: str, *, launch: bool = True) -> Opti
             the source-application (:func:`acquire_service`) so it can be launched.
         (c) Otherwise (when ``launch`` is ``True``), best-effort *launch* the service
             by id by reusing the existing ``nodo execute`` path
-            (:func:`src.commands.execute.execute`).
+            (:func:`src.commands.execute.execute`), injecting ``envs`` into the new
+            instance's environment (e.g. ``SOURCE_SIGNER_MODE``/``SOURCE_MNEMONIC`` to
+            run the source-application as an autonomous seed signer).
+
+    Note: ``envs`` only applies to a *newly launched* instance (c). If an instance is
+    already running (a), its existing environment is used as-is — this never relaunches
+    to change env.
 
     After a download and/or launch attempt, :func:`find_running_endpoint` is re-checked
     and its result returned.
@@ -185,7 +193,7 @@ def ensure_core_service_running(service_id: str, *, launch: bool = True) -> Opti
             # Reuse the canonical launch path; broadly guarded because execute() is
             # side-effectful and depends on a running gateway daemon. BaseException is
             # caught so a stray SystemExit from the execute path can't escape either.
-            execute(service_id)
+            execute(service_id, envs=envs)
         except BaseException:
             # Any launch failure → fall through and re-check below; never raise.
             pass

--- a/src/core_services/runtime.py
+++ b/src/core_services/runtime.py
@@ -1,0 +1,137 @@
+"""Auto-execute a core service: resolve (and, if needed, launch) it by id and
+return a live HTTP endpoint.
+
+This is the runtime symmetry to :mod:`src.core_services.source_application`. Where
+``source_application.acquire_service`` *downloads* a missing core service into the
+local registry, this module makes sure such a service is actually *running* and hands
+the caller a reachable ``http://<ip>:<port>`` endpoint it can talk to. A future
+``nodo pack`` packer path, for example, can call
+:func:`ensure_core_service_running` with the configured ``packer`` core service id and
+get back the live endpoint of a packer instance (downloading + launching it on demand).
+
+Fail-closed / best-effort contract (mirrors source-application's tone):
+    * Nothing here ever raises into the caller. Every step — reading the local
+      instances database, parsing the serialized instance protobuf, acquiring a
+      missing service, launching a service — is wrapped defensively. Any failure
+      (missing table/db, parse error, no rows, no uri, no source-application
+      configured, launch error) degrades to ``None``.
+    * A ``None`` return means "no reachable endpoint for this core service"; the
+      caller is expected to fall back to its existing behaviour rather than assume
+      the service is available.
+    * No new gRPC/gas/storage logic is introduced. Downloading reuses
+      :func:`src.core_services.source_application.acquire_service` and launching
+      reuses the existing ``nodo execute`` path
+      (:func:`src.commands.execute.execute`).
+"""
+
+import sqlite3
+from typing import Optional
+
+from protos import celaut_pb2 as celaut
+from src.utils.config import ConfigManager
+
+_env_manager = ConfigManager()
+
+
+def find_running_endpoint(service_id: str) -> Optional[str]:
+    """Return the first ``http://<ip>:<port>`` of a running instance of ``service_id``.
+
+    Queries the ``local_instances`` table for rows matching ``service_id``, parses each
+    ``serialized_instance`` (a :class:`celaut.Instance` protobuf) and returns the first
+    ``uri_slot[*].uri[*]`` rendered as an HTTP endpoint. Returns ``None`` when no such
+    instance is running or its endpoint cannot be determined.
+
+    Fully defensive: a missing database/table, an unparseable serialized instance, no
+    matching rows, or an instance without any uri all yield ``None`` — this never raises.
+    """
+    try:
+        database_file = _env_manager.get("DATABASE_FILE")
+        if not database_file:
+            return None
+
+        conn = sqlite3.connect(database_file)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT serialized_instance FROM local_instances WHERE service_id = ?",
+                (service_id,),
+            )
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        # Missing db/table, locked db, bad query, etc. — fail closed.
+        return None
+
+    for row in rows:
+        serialized_instance = row[0] if row else None
+        if not serialized_instance:
+            continue
+        try:
+            instance = celaut.Instance()
+            instance.ParseFromString(serialized_instance)
+            for _exp in instance.uri_slot:
+                for _uri in _exp.uri:
+                    ip = str(_uri.ip or "").strip()
+                    port = _uri.port
+                    if ip and port:
+                        return f"http://{ip}:{port}"
+        except Exception:
+            # Unparseable blob for this row — try the next one.
+            continue
+
+    return None
+
+
+def ensure_core_service_running(service_id: str, *, launch: bool = True) -> Optional[str]:
+    """Ensure a core service is running and return its endpoint, or ``None``.
+
+    Resolution order:
+        (a) If an instance of ``service_id`` is already running, return its endpoint.
+        (b) Otherwise, best-effort *download* the service into the local registry via
+            the source-application (:func:`acquire_service`) so it can be launched.
+        (c) Otherwise (when ``launch`` is ``True``), best-effort *launch* the service
+            by id by reusing the existing ``nodo execute`` path
+            (:func:`src.commands.execute.execute`).
+
+    After a download and/or launch attempt, :func:`find_running_endpoint` is re-checked
+    and its result returned.
+
+    Launch wiring: launching reuses ``nodo execute`` rather than re-implementing the
+    gRPC/gas launch logic. ``execute()`` is side-effectful (it prints a launch animation
+    and performs a blocking gRPC call against the local gateway daemon), so the call is
+    wrapped in a broad ``try/except`` — ANY failure (no gateway, missing optional
+    dependency, gRPC error, ``SystemExit``) degrades to ``None`` and never propagates to
+    the caller. ``launch=False`` lets a caller resolve-and-download only (e.g. to check
+    availability) without triggering a launch.
+    """
+    # (a) Already running?
+    endpoint = find_running_endpoint(service_id)
+    if endpoint:
+        return endpoint
+
+    # (b) Not running — make sure it's at least present locally (best-effort download).
+    #     acquire_service is itself fail-closed and returns False when it can't acquire.
+    try:
+        from src.core_services.source_application import acquire_service
+
+        acquire_service(service_id)
+    except Exception:
+        # Defensive: a download failure must not break the ensure path.
+        pass
+
+    # (c) Still not running — attempt to launch via the existing execute path.
+    if launch:
+        try:
+            from src.commands.execute import execute
+
+            # Reuse the canonical launch path; broadly guarded because execute() is
+            # side-effectful and depends on a running gateway daemon. BaseException is
+            # caught so a stray SystemExit from the execute path can't escape either.
+            execute(service_id)
+        except BaseException:
+            # Any launch failure → fall through and re-check below; never raise.
+            pass
+
+    # Re-check for a now-running instance after acquire/launch.
+    return find_running_endpoint(service_id)

--- a/src/core_services/runtime.py
+++ b/src/core_services/runtime.py
@@ -25,7 +25,7 @@ Fail-closed / best-effort contract (mirrors source-application's tone):
 """
 
 import sqlite3
-from typing import Optional
+from typing import Optional, Tuple
 
 from protos import celaut_pb2 as celaut
 from src.utils.config import ConfigManager
@@ -79,6 +79,63 @@ def find_running_endpoint(service_id: str) -> Optional[str]:
         except Exception:
             # Unparseable blob for this row — try the next one.
             continue
+
+    return None
+
+
+def find_running_instance(service_id: str) -> Optional[Tuple[str, Optional[str]]]:
+    """Return ``(instance_token, endpoint)`` for a running instance of ``service_id``.
+
+    Symmetric to :func:`find_running_endpoint` but also returns the instance's
+    ``id`` (its stop token, as accepted by :func:`src.manager.manager.stop_instance`)
+    so a caller can *preempt* the instance, not just talk to it. ``endpoint`` may be
+    ``None`` if the instance is running but has no resolvable uri yet.
+
+    Returns ``None`` when no instance of ``service_id`` is running or its row can't be
+    read. Fully defensive: a missing database/table, an unparseable serialized
+    instance, or no matching rows all yield ``None`` — this never raises.
+    """
+    try:
+        database_file = _env_manager.get("DATABASE_FILE")
+        if not database_file:
+            return None
+
+        conn = sqlite3.connect(database_file)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, serialized_instance FROM local_instances WHERE service_id = ?",
+                (service_id,),
+            )
+            rows = cursor.fetchall()
+        finally:
+            conn.close()
+    except Exception:
+        # Missing db/table, locked db, bad query, etc. — fail closed.
+        return None
+
+    for row in rows:
+        token = str(row[0]) if row and row[0] else None
+        if not token:
+            continue
+        endpoint = None
+        serialized_instance = row[1] if len(row) > 1 else None
+        if serialized_instance:
+            try:
+                instance = celaut.Instance()
+                instance.ParseFromString(serialized_instance)
+                for _exp in instance.uri_slot:
+                    for _uri in _exp.uri:
+                        ip = str(_uri.ip or "").strip()
+                        port = _uri.port
+                        if ip and port:
+                            endpoint = f"http://{ip}:{port}"
+                            break
+                    if endpoint:
+                        break
+            except Exception:
+                endpoint = None
+        return token, endpoint
 
     return None
 

--- a/src/core_services/source_application.py
+++ b/src/core_services/source_application.py
@@ -1,0 +1,156 @@
+"""Auto-acquire a missing service through the ``source-application`` core service.
+
+The source-application is the core service that maps a service id (content hash) to
+the *sources* where that service can be downloaded from (the manifest URLs produced
+by ``nodo publish`` — see :mod:`src.publisher.publisher`). When ``nodo execute`` is
+asked to run a service the node does not have locally, this module asks the
+source-application for that service's sources and downloads it, **reusing the exact
+same acquisition path as ``nodo download``** (:func:`download_from_manifest_url`,
+which fetches the manifest's chunks and imports them into the registry via
+``import_bee``). Nothing here re-implements downloading or storage.
+
+Trust / fail-closed: the fallback is only attempted when a non-placeholder
+``source-application`` id is present in ``core_services`` (see
+:func:`src.core_services.get_core_service_id`). If it is unset, or the lookup/download
+fails, the caller falls back to the existing "Service not allowed." behaviour. The node
+never downloads from an arbitrary, unconfigured source.
+"""
+
+import json
+from typing import List
+from urllib.parse import urlsplit, urlunsplit
+
+from src.core_services import SOURCE_APPLICATION, get_core_service_id
+from src.publisher.publisher import (
+    DEFAULT_SOURCE_APPLICATION_WEB_PAGE,
+    PublisherError,
+    _fetch_bytes,
+    download_from_manifest_url,
+)
+from src.utils.config import ConfigManager
+
+_env_manager = ConfigManager()
+
+
+def _source_application_read_base() -> str:
+    """Origin+path of the source-application, derived from the publisher config.
+
+    ``publisher.SOURCE_APPLICATION_WEB_PAGE`` points at the source-application web app
+    (used by ``nodo publish`` to register sources). We reuse the same deployment for the
+    read side, stripping any query/fragment (e.g. ``?tab=add``) to get the base.
+    """
+    web_page = str(
+        _env_manager.get("publisher.SOURCE_APPLICATION_WEB_PAGE", DEFAULT_SOURCE_APPLICATION_WEB_PAGE)
+        or DEFAULT_SOURCE_APPLICATION_WEB_PAGE
+    ).strip()
+    parts = urlsplit(web_page)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path.rstrip("/"), "", ""))
+
+
+def _parse_sources(payload: bytes) -> List[str]:
+    """Extract manifest URLs from a source-application lookup response.
+
+    Accepts (in order of preference):
+      * JSON list of strings: ``["https://.../manifest", ...]``
+      * JSON list of objects with a ``manifest_url`` / ``urlLink`` / ``url`` field
+      * JSON object with a ``sources`` list of either of the above
+      * newline-delimited plain text, one manifest URL per line
+    """
+    text = payload.decode("utf-8", errors="strict").strip()
+    if not text:
+        return []
+
+    def _from_items(items) -> List[str]:
+        urls: List[str] = []
+        for item in items:
+            if isinstance(item, str):
+                url = item.strip()
+            elif isinstance(item, dict):
+                url = str(
+                    item.get("manifest_url")
+                    or item.get("urlLink")
+                    or item.get("url")
+                    or ""
+                ).strip()
+            else:
+                url = ""
+            if url:
+                urls.append(url)
+        return urls
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return [line.strip() for line in text.splitlines() if line.strip()]
+
+    if isinstance(data, dict):
+        data = data.get("sources", [])
+    if isinstance(data, list):
+        return _from_items(data)
+    return []
+
+
+def lookup_sources(service_id: str) -> List[str]:
+    """Query the source-application for the manifest URLs of ``service_id``.
+
+    Returns a list of manifest URLs (possibly empty). This is the single integration
+    seam with the published source-application service; the read route below is the
+    provisional contract and must be confirmed against the deployed service (tracked by
+    the ``"<SET_ME>"`` id in ``core_services``). All HTTP I/O reuses the publisher's
+    retrying fetch helper rather than introducing a new HTTP client.
+    """
+    base = _source_application_read_base()
+    # Provisional read route: ``<base>/sources/<service_id>``. Confirm against the
+    # published source-application service before un-drafting the PR.
+    url = f"{base}/sources/{service_id}"
+    try:
+        payload = _fetch_bytes(url)
+    except PublisherError:
+        return []
+    return _parse_sources(payload)
+
+
+def acquire_service(service_id: str) -> bool:
+    """Best-effort: download ``service_id`` via the source-application core service.
+
+    Returns ``True`` only if the service was successfully downloaded AND imported into
+    the local registry (so the caller can re-resolve and execute it). Returns ``False``
+    if the source-application is not configured, has no source for the service, or every
+    candidate source fails to download — never raising into the execute path.
+    """
+    source_application_id = get_core_service_id(SOURCE_APPLICATION)
+    if not source_application_id:
+        print(
+            "ℹ️  Skipping auto-download: no 'source-application' core service configured. "
+            "Set its id under 'core_services' in config.yaml to enable resolving missing services."
+        )
+        return False
+
+    print(f"🔎 Looking up '{service_id}' via the source-application core service...")
+    try:
+        sources = lookup_sources(service_id)
+    except Exception as exc:  # defensive: a lookup failure must not break execute
+        print(f"⚠️  source-application lookup failed: {exc}")
+        return False
+
+    if not sources:
+        print("⚠️  source-application returned no sources for this service.")
+        return False
+
+    for manifest_url in sources:
+        try:
+            print(f"⬇️  Downloading service from source: {manifest_url}")
+            result = download_from_manifest_url(manifest_url)
+        except PublisherError as exc:
+            print(f"⚠️  Source failed ({manifest_url}): {exc}")
+            continue
+        except Exception as exc:  # defensive: try the next source
+            print(f"⚠️  Unexpected error downloading from {manifest_url}: {exc}")
+            continue
+
+        if result.get("service_id"):
+            print("✅ Service acquired via source-application.")
+            return True
+
+    print("⚠️  All source-application sources failed to provide the service.")
+    return False

--- a/src/core_services/source_application.py
+++ b/src/core_services/source_application.py
@@ -18,33 +18,18 @@ never downloads from an arbitrary, unconfigured source.
 
 import json
 from typing import List
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote
 
 from src.core_services import SOURCE_APPLICATION, get_core_service_id
 from src.publisher.publisher import (
-    DEFAULT_SOURCE_APPLICATION_WEB_PAGE,
     PublisherError,
     _fetch_bytes,
+    _resolve_source_application_endpoint,
     download_from_manifest_url,
 )
 from src.utils.config import ConfigManager
 
 _env_manager = ConfigManager()
-
-
-def _source_application_read_base() -> str:
-    """Origin+path of the source-application, derived from the publisher config.
-
-    ``publisher.SOURCE_APPLICATION_WEB_PAGE`` points at the source-application web app
-    (used by ``nodo publish`` to register sources). We reuse the same deployment for the
-    read side, stripping any query/fragment (e.g. ``?tab=add``) to get the base.
-    """
-    web_page = str(
-        _env_manager.get("publisher.SOURCE_APPLICATION_WEB_PAGE", DEFAULT_SOURCE_APPLICATION_WEB_PAGE)
-        or DEFAULT_SOURCE_APPLICATION_WEB_PAGE
-    ).strip()
-    parts = urlsplit(web_page)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path.rstrip("/"), "", ""))
 
 
 def _parse_sources(payload: bytes) -> List[str]:
@@ -94,15 +79,19 @@ def lookup_sources(service_id: str) -> List[str]:
     """Query the source-application for the manifest URLs of ``service_id``.
 
     Returns a list of manifest URLs (possibly empty). This is the single integration
-    seam with the published source-application service; the read route below is the
-    provisional contract and must be confirmed against the deployed service (tracked by
-    the ``"<SET_ME>"`` id in ``core_services``). All HTTP I/O reuses the publisher's
+    seam with the published source-application service. The read route is confirmed
+    against the deployed service (``.service/server-http.mjs``): a running instance
+    exposes a JSON REST mirror under ``/api/*`` on port 8080; sources for a file are
+    fetched via ``GET /api/sources?hash=<fileHash>`` (``fetchFileSourcesByHash``). The
+    static web app (``SOURCE_APPLICATION_WEB_PAGE``) has no server API, so reads require
+    a *running* on-node instance — not the web page. All HTTP I/O reuses the publisher's
     retrying fetch helper rather than introducing a new HTTP client.
     """
-    base = _source_application_read_base()
-    # Provisional read route: ``<base>/sources/<service_id>``. Confirm against the
-    # published source-application service before un-drafting the PR.
-    url = f"{base}/sources/{service_id}"
+    endpoint = _resolve_source_application_endpoint()
+    if not endpoint:
+        # No running instance to answer /api reads (the static web app cannot).
+        return []
+    url = f"{endpoint.rstrip('/')}/api/sources?hash={quote(service_id, safe='')}"
     try:
         payload = _fetch_bytes(url)
     except PublisherError:

--- a/src/manager/maintain.py
+++ b/src/manager/maintain.py
@@ -18,6 +18,7 @@ from src.utils.config import ConfigManager
 from src.utils.java_dependency import JavaDependencyMissing, log_java_dependency_warning
 from src.utils.tools.duplicate_grabber import DuplicateGrabber
 from src.virtualizers.interface import maintain as vm_maintain
+from src.core_services.low_demand import scheduler_tick
 
 env_manager = ConfigManager()
 
@@ -284,7 +285,15 @@ def manager_thread():
         maintain_clients(debug_mode=DEBUG_MODE())
         peer_deposits(debug_mode=DEBUG_MODE())
         DuplicateGrabber().manager()
-        
+
+        # Opportunistic low-demand fallback scheduler (OFF unless low_demand.ENABLED).
+        # Self-gates to low_demand.POLL_INTERVAL and never raises; see
+        # src/core_services/low_demand.py and docs/design/low-demand-fallback.md.
+        try:
+            scheduler_tick()
+        except Exception:
+            pass
+
         sleep(MANAGER_ITERATION_TIME)
         if DEBUG_MODE():
             log.LOGGER(f"Long interval count: {short_interval_count}/{SHORT_INTERVAL_COUNT}.")

--- a/src/publisher/publisher.py
+++ b/src/publisher/publisher.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import math
 import os
 import tempfile
@@ -527,11 +528,14 @@ def _build_source_application_prefilled_url(
     )
 
 
-# Provisional write route on a running source-application instance's API. Like the
-# read route in src/core_services/source_application.py (``<base>/sources/<id>``),
-# this contract must be confirmed against the deployed source-application service
-# before the AUTO_PUBLISH_TX path leaves DRAFT.
-SOURCE_APPLICATION_PUBLISH_ROUTE = "publish"
+# Write route on a running source-application instance's REST API, confirmed against
+# the deployed service (``.service/server-http.mjs`` + ``mcp/writes.mjs``): a FILE_SOURCE
+# opinion is published via ``POST /api/sources`` with ``{mainBoxId, fileHash, sourceEntry}``.
+# The instance signs + submits itself when it was launched in seed mode
+# (``SOURCE_SIGNER_MODE=seed`` + ``SOURCE_MNEMONIC`` in its env); the mnemonic is NEVER
+# sent in the request body. In unsigned mode the instance instead returns an unsigned
+# EIP-12 tx (``{submitted:false,...}``) and we fall back to a manual link.
+SOURCE_APPLICATION_PUBLISH_ROUTE = "api/sources"
 
 
 def _resolve_source_application_endpoint() -> Optional[str]:
@@ -558,7 +562,7 @@ def _resolve_source_application_endpoint() -> Optional[str]:
 def _submit_source_via_instance_api(
     endpoint: str,
     *,
-    seed: str,
+    main_box_id: str,
     file_hash: str,
     content_hash: str,
     hash_function_id: str,
@@ -570,31 +574,38 @@ def _submit_source_via_instance_api(
     backoff_s: int,
     is_chunked: bool = True,
 ) -> bool:
-    """AUTO_PUBLISH_TX: hand the source + the node wallet seed to the running
+    """AUTO_PUBLISH_TX: publish the FILE_SOURCE opinion through the running
     source-application instance so it signs and submits the on-chain source
     transaction directly (no manual click-to-add step).
 
-    The seed (``ledgers.ergo.WALLET_MNEMONIC``) is sent to the *local, on-node*
-    source-application instance, which acts as the seed signer. Provisional write
-    contract — confirm the route/payload against the deployed service. Best-effort:
-    returns ``False`` on any failure so the caller falls back to a registration link.
+    Confirmed contract (``.service/server-http.mjs`` → ``mcp/writes.mjs``):
+    ``POST /api/sources`` with ``{mainBoxId, fileHash, sourceEntry}``, where
+    ``sourceEntry = {hashFunctionId, contentFormat, contentHash, rawFormat, urlLink,
+    isChunked}``. ``mainBoxId`` is the node's reputation PROFILE box (its on-chain
+    author identity). The instance signs with its *own* env-configured seed
+    (``SOURCE_SIGNER_MODE=seed`` + ``SOURCE_MNEMONIC``) — the mnemonic is never sent
+    here. The response is ``{submitted:true,txId}`` when signed, or
+    ``{submitted:false,unsignedTransaction,...}`` when the instance runs unsigned; only
+    the former counts as success. Best-effort: returns ``False`` on any failure (or an
+    unsigned result) so the caller falls back to a registration link.
     """
     url = f"{endpoint.rstrip('/')}/{SOURCE_APPLICATION_PUBLISH_ROUTE}"
-    payload = {
-        "fileHash": file_hash,
-        "contentHash": content_hash,
+    source_entry = {
         "hashFunctionId": hash_function_id,
-        "urlLink": manifest_url,
         "contentFormat": content_format,
+        "contentHash": content_hash,
+        "rawFormat": raw_format,
+        "urlLink": manifest_url,
         "isChunked": is_chunked,
-        "seed": seed,
     }
-    if raw_format != content_format:
-        payload["rawFormat"] = raw_format
-        payload["rawHash"] = file_hash
+    payload = {
+        "mainBoxId": main_box_id,
+        "fileHash": file_hash,
+        "sourceEntry": source_entry,
+    }
 
     try:
-        _request_with_retry(
+        response = _request_with_retry(
             "POST",
             url,
             headers={"Content-Type": "application/json"},
@@ -603,13 +614,33 @@ def _submit_source_via_instance_api(
             backoff_s=backoff_s,
             json=payload,
         )
-        return True
     except PublisherError as exc:
         print(f"⚠️  Auto source-tx submit failed: {exc}", flush=True)
         return False
     except Exception as exc:  # defensive: the auto path must never break publish
         print(f"⚠️  Auto source-tx submit errored: {exc}", flush=True)
         return False
+
+    # The instance only actually signed + submitted when running in seed mode; an
+    # unsigned instance returns {submitted:false, unsignedTransaction}. Treat only a
+    # confirmed submit as success so the caller can fall back to a manual link.
+    try:
+        body = json.loads(response.content.decode("utf-8", errors="strict"))
+    except Exception:
+        # No parseable body but the POST itself succeeded — assume the instance
+        # accepted it (older/leaner instances may return an empty 200).
+        return True
+    if isinstance(body, dict) and body.get("submitted") is False:
+        tx = body.get("unsignedTransaction")
+        if tx is not None:
+            print(
+                "↩️  source-application instance is in unsigned mode (returned an "
+                "unsigned tx) — it cannot auto-submit. Launch it with "
+                "SOURCE_SIGNER_MODE=seed + SOURCE_MNEMONIC to enable AUTO_PUBLISH_TX.",
+                flush=True,
+            )
+        return False
+    return True
 
 
 def _print_click_to_add(
@@ -656,37 +687,45 @@ def _announce_source_registration(
 ) -> None:
     """Decide, across four levels, how the freshly-published source is registered.
 
-    1. ``AUTO_PUBLISH_TX`` on **and** a running source-application instance →
-       submit the source transaction through the instance API, signed with the
-       node wallet seed (no manual step).
-    2. A running instance but ``AUTO_PUBLISH_TX`` off (or the auto submit fell
-       back) → print a click-to-add link against the instance's web page.
-    3. No instance, but ``publisher.SOURCE_APPLICATION_WEB_PAGE`` is set → print a
-       click-to-add link against that page (the pre-existing behaviour).
-    4. No instance and no web page configured → a manual-registration message.
+    1. ``AUTO_PUBLISH_TX`` on, a running source-application instance, **and** a
+       configured PROFILE box (``publisher.SOURCE_PROFILE_BOX_ID``) → publish the
+       FILE_SOURCE opinion through the instance's ``POST /api/sources``. The instance
+       signs with its own env-configured seed (see ``_submit_source_via_instance_api``).
+    2. A running instance but auto-submit off/unavailable, and a web page is
+       configured → a prefilled click-to-add link on the **web app** (the running
+       instance serves only ``/api`` + ``/mcp`` JSON, never the prefill UI).
+    3. No instance, but ``publisher.SOURCE_APPLICATION_WEB_PAGE`` is set → the same
+       prefilled click-to-add link (the pre-existing behaviour).
+    4. Nothing usable → a manual-registration message.
+
+    The manual link (levels 2–3) always targets the configured web app, never a bare
+    instance endpoint, because only the static web app renders the prefilled add form.
     """
     hash_function_id = settings["hash_spec"].id_bytes.hex()
     endpoint = _resolve_source_application_endpoint()
     web_page = settings["source_application_web_page"]
 
-    # Level 1 — auto-submit via the running instance, signed with the node seed.
+    # Level 1 — auto-submit the FILE_SOURCE opinion via the running instance's REST API.
     if endpoint and settings["auto_publish_tx"]:
-        seed = str(ConfigManager().get("ledgers.ergo.WALLET_MNEMONIC", "") or "").strip()
-        if not seed:
+        main_box_id = str(ConfigManager().get("publisher.SOURCE_PROFILE_BOX_ID", "") or "").strip()
+        if not main_box_id:
             print(
-                "⚠️  AUTO_PUBLISH_TX is enabled but ledgers.ergo.WALLET_MNEMONIC is empty — "
-                "cannot sign the source transaction. Falling back to a registration link.",
+                "⚠️  AUTO_PUBLISH_TX is enabled but publisher.SOURCE_PROFILE_BOX_ID is unset — "
+                "the on-chain opinion needs the node's reputation PROFILE box id as its author. "
+                "Mint a profile once (source-application web app or POST /api/profile) and set "
+                "its box id in config. Falling back to a registration link.",
                 flush=True,
             )
         else:
             print(
-                "AUTO_PUBLISH_TX enabled — submitting the source transaction via the running "
-                "source-application instance (signed with the node wallet seed)...",
+                "AUTO_PUBLISH_TX enabled — publishing the source opinion via the running "
+                "source-application instance (POST /api/sources; the instance signs with its "
+                "own seed)...",
                 flush=True,
             )
             submitted = _submit_source_via_instance_api(
                 endpoint,
-                seed=seed,
+                main_box_id=main_box_id,
                 file_hash=service_id,
                 content_hash=content_hash,
                 hash_function_id=hash_function_id,
@@ -708,20 +747,8 @@ def _announce_source_registration(
                 flush=True,
             )
 
-    # Level 2 — a running instance exists: link against its web page.
-    if endpoint:
-        _print_click_to_add(
-            endpoint,
-            file_hash=service_id,
-            content_hash=content_hash,
-            hash_function_id=hash_function_id,
-            manifest_url=manifest_url,
-            content_format=settings["content_format"],
-            raw_format=settings["raw_format"],
-        )
-        return
-
-    # Level 3 — no instance, but a source-application web page is configured.
+    # Levels 2 & 3 — a prefilled click-to-add link on the configured web app. A running
+    # instance does not change the target: only the static web app renders the add form.
     if web_page:
         _print_click_to_add(
             web_page,
@@ -736,8 +763,8 @@ def _announce_source_registration(
 
     # Level 4 — nothing configured: tell the user how to register manually.
     print(
-        "ℹ️  Source uploaded, but no source-application instance is running and "
-        "publisher.SOURCE_APPLICATION_WEB_PAGE is not set. Register the source manually "
+        "ℹ️  Source uploaded, but no source registration path is available "
+        "(publisher.SOURCE_APPLICATION_WEB_PAGE is not set). Register the source manually "
         "using the file hash, content hash and manifest URL above.",
         flush=True,
     )

--- a/src/publisher/publisher.py
+++ b/src/publisher/publisher.py
@@ -294,9 +294,19 @@ def _get_publisher_settings(config: ConfigManager, require_token: bool = True) -
         hash_spec = get_configured_hash_spec(config)
     except ValueError as exc:
         raise PublisherError(f"Invalid hashing.HASH configuration: {exc}") from exc
+    # Raw configured value (may be empty). We deliberately do NOT fall back to
+    # DEFAULT_SOURCE_APPLICATION_WEB_PAGE here: an unset web page is a meaningful
+    # signal to the publish flow — it selects the level-4 "register manually"
+    # message rather than silently pointing at the public default page
+    # (see _announce_source_registration). The default is still used as the read
+    # base by src/core_services/source_application.py.
     source_application_web_page = str(
-        config.get("publisher.SOURCE_APPLICATION_WEB_PAGE", DEFAULT_SOURCE_APPLICATION_WEB_PAGE) or ""
-    ).strip() or DEFAULT_SOURCE_APPLICATION_WEB_PAGE
+        config.get("publisher.SOURCE_APPLICATION_WEB_PAGE", "") or ""
+    ).strip()
+    # When enabled AND a source-application core-service instance is running, the
+    # publish flow submits the source transaction directly through that instance's
+    # API (signed with the node wallet seed) instead of printing a click-to-add link.
+    auto_publish_tx = bool(config.get("publisher.AUTO_PUBLISH_TX", False))
     content_format = str(config.get("publisher.CONTENT_FORMAT", ".grpcbb") or "").strip() or ".grpcbb"
     raw_format = str(config.get("publisher.RAW_FORMAT", ".celaut") or "").strip() or ".celaut"
     if not content_format.startswith("."):
@@ -329,6 +339,7 @@ def _get_publisher_settings(config: ConfigManager, require_token: bool = True) -
         "branch": branch,
         "hash_spec": hash_spec,
         "source_application_web_page": source_application_web_page,
+        "auto_publish_tx": auto_publish_tx,
         "content_format": content_format,
         "raw_format": raw_format,
         "chunk_size_mb": chunk_size_mb,
@@ -516,6 +527,222 @@ def _build_source_application_prefilled_url(
     )
 
 
+# Provisional write route on a running source-application instance's API. Like the
+# read route in src/core_services/source_application.py (``<base>/sources/<id>``),
+# this contract must be confirmed against the deployed source-application service
+# before the AUTO_PUBLISH_TX path leaves DRAFT.
+SOURCE_APPLICATION_PUBLISH_ROUTE = "publish"
+
+
+def _resolve_source_application_endpoint() -> Optional[str]:
+    """Return the endpoint of a *running* source-application core-service instance.
+
+    Requires a configured (non-placeholder) ``source-application`` id under
+    ``core_services`` AND a currently-running instance of it; returns ``None``
+    otherwise. Detection only — it never downloads or launches the service, so a
+    publish never triggers heavy side effects. Fully defensive: never raises.
+    """
+    try:
+        from src.core_services import SOURCE_APPLICATION, get_core_service_id
+        from src.core_services.runtime import find_running_endpoint
+
+        source_application_id = get_core_service_id(SOURCE_APPLICATION)
+        if not source_application_id:
+            return None
+        return find_running_endpoint(source_application_id)
+    except Exception:
+        # Missing core_services infra / db / parse error — treat as "no instance".
+        return None
+
+
+def _submit_source_via_instance_api(
+    endpoint: str,
+    *,
+    seed: str,
+    file_hash: str,
+    content_hash: str,
+    hash_function_id: str,
+    manifest_url: str,
+    content_format: str,
+    raw_format: str,
+    timeout_s: int,
+    max_retry: int,
+    backoff_s: int,
+    is_chunked: bool = True,
+) -> bool:
+    """AUTO_PUBLISH_TX: hand the source + the node wallet seed to the running
+    source-application instance so it signs and submits the on-chain source
+    transaction directly (no manual click-to-add step).
+
+    The seed (``ledgers.ergo.WALLET_MNEMONIC``) is sent to the *local, on-node*
+    source-application instance, which acts as the seed signer. Provisional write
+    contract — confirm the route/payload against the deployed service. Best-effort:
+    returns ``False`` on any failure so the caller falls back to a registration link.
+    """
+    url = f"{endpoint.rstrip('/')}/{SOURCE_APPLICATION_PUBLISH_ROUTE}"
+    payload = {
+        "fileHash": file_hash,
+        "contentHash": content_hash,
+        "hashFunctionId": hash_function_id,
+        "urlLink": manifest_url,
+        "contentFormat": content_format,
+        "isChunked": is_chunked,
+        "seed": seed,
+    }
+    if raw_format != content_format:
+        payload["rawFormat"] = raw_format
+        payload["rawHash"] = file_hash
+
+    try:
+        _request_with_retry(
+            "POST",
+            url,
+            headers={"Content-Type": "application/json"},
+            timeout_s=timeout_s,
+            max_retry=max_retry,
+            backoff_s=backoff_s,
+            json=payload,
+        )
+        return True
+    except PublisherError as exc:
+        print(f"⚠️  Auto source-tx submit failed: {exc}", flush=True)
+        return False
+    except Exception as exc:  # defensive: the auto path must never break publish
+        print(f"⚠️  Auto source-tx submit errored: {exc}", flush=True)
+        return False
+
+
+def _print_click_to_add(
+    base_url: str,
+    *,
+    file_hash: str,
+    content_hash: str,
+    hash_function_id: str,
+    manifest_url: str,
+    content_format: str,
+    raw_format: str,
+) -> None:
+    """Print the manual "click to add source" block against ``base_url``."""
+    prefilled_url = _build_source_application_prefilled_url(
+        base_url=base_url,
+        file_hash=file_hash,
+        content_hash=content_hash,
+        hash_function_id=hash_function_id,
+        url_link=manifest_url,
+        content_format=content_format,
+        raw_format=raw_format,
+        is_chunked=True,
+    )
+    print("Register this source in Source Application:", flush=True)
+    print(f"- Source application URL: {base_url}", flush=True)
+    print(f"- Source application prefilled URL: {prefilled_url}", flush=True)
+    print(f"- Manifest URL: {manifest_url}", flush=True)
+    print(f"- File hash: {file_hash}", flush=True)
+    print(f"- Content hash: {content_hash}", flush=True)
+
+    BOLD = "\033[1m"
+    GREEN = "\033[92m"
+    RESET = "\033[0m"
+    print(f"\n\n{BOLD}{GREEN}👉 CLICK TO ADD SOURCE IN ERGO:{RESET}", flush=True)
+    print(f"{GREEN}{prefilled_url}{RESET}\n", flush=True)
+
+
+def _announce_source_registration(
+    settings: Dict,
+    *,
+    service_id: str,
+    content_hash: str,
+    manifest_url: str,
+) -> None:
+    """Decide, across four levels, how the freshly-published source is registered.
+
+    1. ``AUTO_PUBLISH_TX`` on **and** a running source-application instance →
+       submit the source transaction through the instance API, signed with the
+       node wallet seed (no manual step).
+    2. A running instance but ``AUTO_PUBLISH_TX`` off (or the auto submit fell
+       back) → print a click-to-add link against the instance's web page.
+    3. No instance, but ``publisher.SOURCE_APPLICATION_WEB_PAGE`` is set → print a
+       click-to-add link against that page (the pre-existing behaviour).
+    4. No instance and no web page configured → a manual-registration message.
+    """
+    hash_function_id = settings["hash_spec"].id_bytes.hex()
+    endpoint = _resolve_source_application_endpoint()
+    web_page = settings["source_application_web_page"]
+
+    # Level 1 — auto-submit via the running instance, signed with the node seed.
+    if endpoint and settings["auto_publish_tx"]:
+        seed = str(ConfigManager().get("ledgers.ergo.WALLET_MNEMONIC", "") or "").strip()
+        if not seed:
+            print(
+                "⚠️  AUTO_PUBLISH_TX is enabled but ledgers.ergo.WALLET_MNEMONIC is empty — "
+                "cannot sign the source transaction. Falling back to a registration link.",
+                flush=True,
+            )
+        else:
+            print(
+                "AUTO_PUBLISH_TX enabled — submitting the source transaction via the running "
+                "source-application instance (signed with the node wallet seed)...",
+                flush=True,
+            )
+            submitted = _submit_source_via_instance_api(
+                endpoint,
+                seed=seed,
+                file_hash=service_id,
+                content_hash=content_hash,
+                hash_function_id=hash_function_id,
+                manifest_url=manifest_url,
+                content_format=settings["content_format"],
+                raw_format=settings["raw_format"],
+                timeout_s=settings["timeout_s"],
+                max_retry=settings["max_retry"],
+                backoff_s=settings["backoff_s"],
+            )
+            if submitted:
+                print(
+                    "✅ Source transaction submitted directly via the source-application instance.",
+                    flush=True,
+                )
+                return
+            print(
+                "↩️  Auto submit unsuccessful — showing a manual registration link instead.",
+                flush=True,
+            )
+
+    # Level 2 — a running instance exists: link against its web page.
+    if endpoint:
+        _print_click_to_add(
+            endpoint,
+            file_hash=service_id,
+            content_hash=content_hash,
+            hash_function_id=hash_function_id,
+            manifest_url=manifest_url,
+            content_format=settings["content_format"],
+            raw_format=settings["raw_format"],
+        )
+        return
+
+    # Level 3 — no instance, but a source-application web page is configured.
+    if web_page:
+        _print_click_to_add(
+            web_page,
+            file_hash=service_id,
+            content_hash=content_hash,
+            hash_function_id=hash_function_id,
+            manifest_url=manifest_url,
+            content_format=settings["content_format"],
+            raw_format=settings["raw_format"],
+        )
+        return
+
+    # Level 4 — nothing configured: tell the user how to register manually.
+    print(
+        "ℹ️  Source uploaded, but no source-application instance is running and "
+        "publisher.SOURCE_APPLICATION_WEB_PAGE is not set. Register the source manually "
+        "using the file hash, content hash and manifest URL above.",
+        flush=True,
+    )
+
+
 def publish_service(
     service_ref: str
 ) -> Dict:
@@ -545,17 +772,6 @@ def publish_service(
         if service_file_path.exists():
             service_file_path.unlink()
 
-    source_application_prefilled_url = _build_source_application_prefilled_url(
-        base_url=settings["source_application_web_page"],
-        file_hash=service_id,
-        content_hash=content_hash,
-        hash_function_id=settings["hash_spec"].id_bytes.hex(),  # Sending hash function id as hex string for better readability in the source application, could be the name but id is more precise.
-        url_link=result["manifest_url"],
-        content_format=settings["content_format"],
-        raw_format=settings["raw_format"],
-        is_chunked=True,
-    )
-
     print("Publish completed successfully.", flush=True)
     print(f"Service id: {service_id}", flush=True)
     print(f"File hash: {service_id}", flush=True)
@@ -563,18 +779,15 @@ def publish_service(
     print(f"Manifest URL: {result['manifest_url']}", flush=True)
     print(f"Manifest browser URL: {result['browse_manifest_url']}", flush=True)
     print(f"Download command: nodo download {result['manifest_url']}", flush=True)
-    print("Register this source in Source Application:", flush=True)
-    print(f"- Source application URL: {settings['source_application_web_page']}", flush=True)
-    print(f"- Source application prefilled URL: {source_application_prefilled_url}", flush=True)
-    print(f"- Manifest URL: {result['manifest_url']}", flush=True)
-    print(f"- File hash: {service_id}", flush=True)
-    print(f"- Content hash: {content_hash}", flush=True)
 
-    BOLD = "\033[1m"
-    GREEN = "\033[92m"
-    RESET = "\033[0m"
-    print(f"\n\n{BOLD}{GREEN}👉 CLICK TO ADD SOURCE IN ERGO:{RESET}", flush=True)
-    print(f"{GREEN}{source_application_prefilled_url}{RESET}\n", flush=True)
+    # Four-level source registration (auto-tx via instance / instance link /
+    # configured web page link / manual message). See _announce_source_registration.
+    _announce_source_registration(
+        settings,
+        service_id=service_id,
+        content_hash=content_hash,
+        manifest_url=result["manifest_url"],
+    )
     return result
 
 

--- a/src/publisher/publisher.py
+++ b/src/publisher/publisher.py
@@ -559,6 +559,50 @@ def _resolve_source_application_endpoint() -> Optional[str]:
         return None
 
 
+def _build_source_signer_envs() -> Optional[Dict[str, str]]:
+    """Seed-signer environment for an auto-launched source-application instance.
+
+    Maps the node's Ergo wallet into the env the service reads (see the deployed
+    service's ``mcp/lib.mjs``): ``SOURCE_SIGNER_MODE=seed`` + ``SOURCE_MNEMONIC`` so the
+    instance signs + submits the source transaction itself, and ``SOURCE_NODE_URI`` for
+    submission. Returns ``None`` when no wallet mnemonic is configured (can't run a seed
+    signer), so the caller degrades to a manual link.
+    """
+    cfg = ConfigManager()
+    mnemonic = str(cfg.get("ledgers.ergo.WALLET_MNEMONIC", "") or "").strip()
+    if not mnemonic:
+        return None
+    envs = {"SOURCE_SIGNER_MODE": "seed", "SOURCE_MNEMONIC": mnemonic}
+    node_url = str(cfg.get("ledgers.ergo.NODE_URL", "") or "").strip()
+    if node_url:
+        envs["SOURCE_NODE_URI"] = node_url
+    return envs
+
+
+def _ensure_seed_mode_source_application() -> Optional[str]:
+    """Return a running source-application endpoint, auto-launching one in seed mode.
+
+    For AUTO_PUBLISH_TX: reuse an already-running instance if present, otherwise launch
+    the configured ``source-application`` core service with the node's seed injected into
+    its environment (``_build_source_signer_envs``) so it can sign + submit autonomously.
+    Fully defensive — a missing core-service id, no wallet mnemonic, or any launch failure
+    yields ``None`` and the caller falls back to a manual registration link.
+    """
+    try:
+        from src.core_services import SOURCE_APPLICATION, get_core_service_id
+        from src.core_services.runtime import ensure_core_service_running
+
+        source_application_id = get_core_service_id(SOURCE_APPLICATION)
+        if not source_application_id:
+            return None
+        envs = _build_source_signer_envs()
+        if not envs:
+            return None  # no seed to run the instance as a signer
+        return ensure_core_service_running(source_application_id, envs=envs)
+    except Exception:
+        return None
+
+
 def _submit_source_via_instance_api(
     endpoint: str,
     *,
@@ -687,10 +731,11 @@ def _announce_source_registration(
 ) -> None:
     """Decide, across four levels, how the freshly-published source is registered.
 
-    1. ``AUTO_PUBLISH_TX`` on, a running source-application instance, **and** a
-       configured PROFILE box (``publisher.SOURCE_PROFILE_BOX_ID``) → publish the
-       FILE_SOURCE opinion through the instance's ``POST /api/sources``. The instance
-       signs with its own env-configured seed (see ``_submit_source_via_instance_api``).
+    1. ``AUTO_PUBLISH_TX`` on **and** a configured PROFILE box
+       (``publisher.SOURCE_PROFILE_BOX_ID``) → publish the FILE_SOURCE opinion through
+       a source-application instance's ``POST /api/sources``. The node **auto-launches**
+       the instance in seed mode (node wallet mnemonic injected into its env) if one
+       isn't already running, so it signs + submits the tx itself.
     2. A running instance but auto-submit off/unavailable, and a web page is
        configured → a prefilled click-to-add link on the **web app** (the running
        instance serves only ``/api`` + ``/mcp`` JSON, never the prefill UI).
@@ -702,11 +747,11 @@ def _announce_source_registration(
     instance endpoint, because only the static web app renders the prefilled add form.
     """
     hash_function_id = settings["hash_spec"].id_bytes.hex()
-    endpoint = _resolve_source_application_endpoint()
     web_page = settings["source_application_web_page"]
 
-    # Level 1 — auto-submit the FILE_SOURCE opinion via the running instance's REST API.
-    if endpoint and settings["auto_publish_tx"]:
+    # Level 1 — auto-submit the FILE_SOURCE opinion via a seed-mode instance (launching
+    # one with the node seed in its env if necessary).
+    if settings["auto_publish_tx"]:
         main_box_id = str(ConfigManager().get("publisher.SOURCE_PROFILE_BOX_ID", "") or "").strip()
         if not main_box_id:
             print(
@@ -718,34 +763,42 @@ def _announce_source_registration(
             )
         else:
             print(
-                "AUTO_PUBLISH_TX enabled — publishing the source opinion via the running "
-                "source-application instance (POST /api/sources; the instance signs with its "
-                "own seed)...",
+                "AUTO_PUBLISH_TX enabled — ensuring a seed-mode source-application instance "
+                "and publishing the source opinion (POST /api/sources)...",
                 flush=True,
             )
-            submitted = _submit_source_via_instance_api(
-                endpoint,
-                main_box_id=main_box_id,
-                file_hash=service_id,
-                content_hash=content_hash,
-                hash_function_id=hash_function_id,
-                manifest_url=manifest_url,
-                content_format=settings["content_format"],
-                raw_format=settings["raw_format"],
-                timeout_s=settings["timeout_s"],
-                max_retry=settings["max_retry"],
-                backoff_s=settings["backoff_s"],
-            )
-            if submitted:
+            endpoint = _ensure_seed_mode_source_application()
+            if not endpoint:
                 print(
-                    "✅ Source transaction submitted directly via the source-application instance.",
+                    "⚠️  Could not start a seed-mode source-application instance "
+                    "(need a configured 'source-application' core service + "
+                    "ledgers.ergo.WALLET_MNEMONIC + a running gateway). Falling back to a link.",
                     flush=True,
                 )
-                return
-            print(
-                "↩️  Auto submit unsuccessful — showing a manual registration link instead.",
-                flush=True,
-            )
+            else:
+                submitted = _submit_source_via_instance_api(
+                    endpoint,
+                    main_box_id=main_box_id,
+                    file_hash=service_id,
+                    content_hash=content_hash,
+                    hash_function_id=hash_function_id,
+                    manifest_url=manifest_url,
+                    content_format=settings["content_format"],
+                    raw_format=settings["raw_format"],
+                    timeout_s=settings["timeout_s"],
+                    max_retry=settings["max_retry"],
+                    backoff_s=settings["backoff_s"],
+                )
+                if submitted:
+                    print(
+                        "✅ Source transaction submitted directly via the source-application instance.",
+                        flush=True,
+                    )
+                    return
+                print(
+                    "↩️  Auto submit unsuccessful — showing a manual registration link instead.",
+                    flush=True,
+                )
 
     # Levels 2 & 3 — a prefilled click-to-add link on the configured web app. A running
     # instance does not change the target: only the static web app renders the add form.

--- a/tests/test_core_services.py
+++ b/tests/test_core_services.py
@@ -1,0 +1,187 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+IMPORT_ERROR = None
+try:
+    from src import core_services
+    from src.core_services import source_application as sa
+    from src.commands import execute as execute_cmd
+    from protos import celaut_pb2 as celaut
+except Exception as import_exc:  # pragma: no cover - environment-dependent
+    IMPORT_ERROR = import_exc
+    core_services = None  # type: ignore[assignment]
+    sa = None  # type: ignore[assignment]
+    execute_cmd = None  # type: ignore[assignment]
+    celaut = None  # type: ignore[assignment]
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class CoreServiceIdAccessorTests(unittest.TestCase):
+    def _patch_config(self, value):
+        return patch.object(core_services._env_manager, "get", return_value=value)
+
+    def test_returns_id_for_matching_role(self):
+        with self._patch_config([{"name": "source-application", "id": "abc123"}]):
+            self.assertEqual(
+                core_services.get_core_service_id("source-application"), "abc123"
+            )
+
+    def test_placeholder_is_treated_as_unset(self):
+        with self._patch_config([{"name": "source-application", "id": "<SET_ME>"}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_blank_id_is_unset(self):
+        with self._patch_config([{"name": "source-application", "id": "  "}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_missing_role_returns_none(self):
+        with self._patch_config([{"name": "packer", "id": "abc"}]):
+            self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+    def test_empty_or_invalid_config_returns_none(self):
+        for value in ([], None, "not-a-list"):
+            with self._patch_config(value):
+                self.assertIsNone(core_services.get_core_service_id("source-application"))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class ParseSourcesTests(unittest.TestCase):
+    def test_json_list_of_strings(self):
+        self.assertEqual(
+            sa._parse_sources(b'["https://h/manifest", "https://h2/manifest"]'),
+            ["https://h/manifest", "https://h2/manifest"],
+        )
+
+    def test_json_list_of_objects(self):
+        payload = b'[{"manifest_url": "https://h/m"}, {"urlLink": "https://h2/m"}]'
+        self.assertEqual(sa._parse_sources(payload), ["https://h/m", "https://h2/m"])
+
+    def test_json_object_with_sources_key(self):
+        self.assertEqual(
+            sa._parse_sources(b'{"sources": ["https://h/m"]}'), ["https://h/m"]
+        )
+
+    def test_plaintext_fallback(self):
+        self.assertEqual(
+            sa._parse_sources(b"https://h/m\nhttps://h2/m\n"),
+            ["https://h/m", "https://h2/m"],
+        )
+
+    def test_empty(self):
+        self.assertEqual(sa._parse_sources(b"  "), [])
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class AcquireServiceTests(unittest.TestCase):
+    def test_returns_false_when_not_configured(self):
+        out = io.StringIO()
+        with patch.object(sa, "get_core_service_id", return_value=None):
+            with redirect_stdout(out):
+                self.assertFalse(sa.acquire_service("svc"))
+        self.assertIn("no 'source-application' core service configured", out.getvalue())
+
+    def test_returns_false_when_no_sources(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=[]
+        ):
+            self.assertFalse(sa.acquire_service("svc"))
+
+    def test_downloads_first_good_source(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://h/m"]
+        ), patch.object(
+            sa, "download_from_manifest_url", return_value={"service_id": "svc"}
+        ) as mock_dl:
+            self.assertTrue(sa.acquire_service("svc"))
+        mock_dl.assert_called_once_with("https://h/m")
+
+    def test_tries_next_source_on_failure(self):
+        def dl(url):
+            if url == "https://bad/m":
+                raise sa.PublisherError("boom")
+            return {"service_id": "svc"}
+
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://bad/m", "https://good/m"]
+        ), patch.object(sa, "download_from_manifest_url", side_effect=dl):
+            self.assertTrue(sa.acquire_service("svc"))
+
+    def test_returns_false_when_all_sources_fail(self):
+        with patch.object(sa, "get_core_service_id", return_value="sa-id"), patch.object(
+            sa, "lookup_sources", return_value=["https://h/m"]
+        ), patch.object(
+            sa, "download_from_manifest_url", return_value={"service_id": None}
+        ):
+            self.assertFalse(sa.acquire_service("svc"))
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class ExecuteFallbackTests(unittest.TestCase):
+    def _response_with_slot(self):
+        response = celaut.ServiceInstance()
+        slot = response.instance.api.slot.add()
+        slot.port = 5000
+        slot.transport.tags.extend(["http"])
+        uri_slot = response.instance.uri_slot.add()
+        uri_slot.internal_port = 5000
+        uri = uri_slot.uri.add()
+        uri.ip = "127.0.0.1"
+        uri.port = 18080
+        return response
+
+    def test_falls_back_to_acquire_then_reresolves_and_runs(self):
+        response = self._response_with_slot()
+        # First resolve fails, acquire succeeds, second resolve returns the hash.
+        with patch.object(
+            execute_cmd, "resolve_service_hash", side_effect=["", "svc"]
+        ) as mock_resolve, patch.object(
+            execute_cmd, "acquire_service", return_value=True
+        ) as mock_acquire, patch.object(
+            execute_cmd.grpc, "insecure_channel"
+        ), patch.object(
+            execute_cmd.celaut_pb2_grpc, "GatewayStub"
+        ) as mock_stub_cls, patch.object(
+            execute_cmd, "inspect_service"
+        ), patch.object(
+            execute_cmd, "client_grpc", return_value=iter([response])
+        ):
+            mock_stub_cls.return_value.StartService = object()
+            execute_cmd.execute("svc")
+
+        mock_acquire.assert_called_once_with("svc")
+        self.assertEqual(mock_resolve.call_count, 2)
+
+    def test_prints_not_allowed_when_acquire_fails(self):
+        out = io.StringIO()
+        with patch.object(
+            execute_cmd, "resolve_service_hash", return_value=""
+        ), patch.object(execute_cmd, "acquire_service", return_value=False):
+            with redirect_stdout(out):
+                execute_cmd.execute("svc")
+        self.assertIn("Service not allowed.", out.getvalue())
+
+    def test_does_not_acquire_when_already_resolvable(self):
+        response = self._response_with_slot()
+        with patch.object(
+            execute_cmd, "resolve_service_hash", return_value="svc"
+        ), patch.object(
+            execute_cmd, "acquire_service"
+        ) as mock_acquire, patch.object(
+            execute_cmd.grpc, "insecure_channel"
+        ), patch.object(
+            execute_cmd.celaut_pb2_grpc, "GatewayStub"
+        ) as mock_stub_cls, patch.object(
+            execute_cmd, "inspect_service"
+        ), patch.object(
+            execute_cmd, "client_grpc", return_value=iter([response])
+        ):
+            mock_stub_cls.return_value.StartService = object()
+            execute_cmd.execute("svc")
+
+        mock_acquire.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_services_runtime.py
+++ b/tests/test_core_services_runtime.py
@@ -172,7 +172,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
 
         self.assertIsNone(result)
         acquire.assert_called_once_with("svc")
-        launch.assert_called_once_with("svc")
+        launch.assert_called_once_with("svc", envs=None)
 
     def test_launch_error_is_swallowed_and_returns_none(self):
         acquire = MagicMock(return_value=False)
@@ -184,7 +184,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
             result = runtime.ensure_core_service_running("svc")
 
         self.assertIsNone(result)
-        launch.assert_called_once_with("svc")
+        launch.assert_called_once_with("svc", envs=None)
 
     def test_endpoint_appears_after_launch(self):
         # First check (top) returns None, second check (bottom) returns endpoint.
@@ -198,7 +198,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
             result = runtime.ensure_core_service_running("svc")
 
         self.assertEqual(result, "http://10.0.0.9:7000")
-        launch.assert_called_once_with("svc")
+        launch.assert_called_once_with("svc", envs=None)
 
 
 if __name__ == "__main__":

--- a/tests/test_core_services_runtime.py
+++ b/tests/test_core_services_runtime.py
@@ -1,0 +1,205 @@
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+IMPORT_ERROR = None
+try:
+    from src.core_services import runtime
+    from protos import celaut_pb2 as celaut
+except Exception as import_exc:  # pragma: no cover - environment-dependent
+    IMPORT_ERROR = import_exc
+    runtime = None  # type: ignore[assignment]
+    celaut = None  # type: ignore[assignment]
+
+
+def _serialized_instance(ip="127.0.0.1", port=18080, internal_port=5000):
+    instance = celaut.Instance()
+    uri_slot = instance.uri_slot.add()
+    uri_slot.internal_port = internal_port
+    uri = uri_slot.uri.add()
+    uri.ip = ip
+    uri.port = port
+    return instance.SerializeToString()
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, raise_on_execute=None):
+        self._rows = rows or []
+        self._raise = raise_on_execute
+
+    def execute(self, *args, **kwargs):
+        if self._raise is not None:
+            raise self._raise
+        return self
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def _patch_db(rows=None, raise_on_execute=None, raise_on_connect=None):
+    """Patch sqlite3.connect + DATABASE_FILE config used by runtime.find_running_endpoint."""
+    cursor = _FakeCursor(rows=rows, raise_on_execute=raise_on_execute)
+
+    def fake_connect(_path):
+        if raise_on_connect is not None:
+            raise raise_on_connect
+        return _FakeConn(cursor)
+
+    return (
+        patch.object(runtime._env_manager, "get", return_value="/tmp/fake-database.sqlite"),
+        patch.object(runtime.sqlite3, "connect", side_effect=fake_connect),
+    )
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class FindRunningEndpointTests(unittest.TestCase):
+    def test_returns_endpoint_when_instance_running(self):
+        rows = [(_serialized_instance(ip="10.0.0.5", port=9000),)]
+        cfg, conn = _patch_db(rows=rows)
+        with cfg, conn:
+            self.assertEqual(
+                runtime.find_running_endpoint("svc"), "http://10.0.0.5:9000"
+            )
+
+    def test_returns_none_when_no_rows(self):
+        cfg, conn = _patch_db(rows=[])
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_missing_table_returns_none(self):
+        # Simulate `no such table: local_instances`.
+        cfg, conn = _patch_db(raise_on_execute=Exception("no such table: local_instances"))
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_unparseable_blob_returns_none(self):
+        cfg, conn = _patch_db(rows=[(b"\xff\xff not a protobuf",)])
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_missing_database_file_returns_none(self):
+        with patch.object(runtime._env_manager, "get", return_value=None):
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+    def test_connect_failure_returns_none(self):
+        cfg, conn = _patch_db(raise_on_connect=sqlite3_error())
+        with cfg, conn:
+            self.assertIsNone(runtime.find_running_endpoint("svc"))
+
+
+def sqlite3_error():
+    import sqlite3
+
+    return sqlite3.OperationalError("unable to open database file")
+
+
+@contextmanager
+def _stub_deps(acquire, launch):
+    """Inject stub modules so runtime.py's lazy imports of source_application/execute
+    resolve to our mocks without dragging in the real (bee_rpc-dependent) modules."""
+    sa_mod = types.ModuleType("src.core_services.source_application")
+    sa_mod.acquire_service = acquire
+    exec_mod = types.ModuleType("src.commands.execute")
+    exec_mod.execute = launch
+
+    originals = {
+        "src.core_services.source_application": sys.modules.get(
+            "src.core_services.source_application"
+        ),
+        "src.commands.execute": sys.modules.get("src.commands.execute"),
+    }
+    sys.modules["src.core_services.source_application"] = sa_mod
+    sys.modules["src.commands.execute"] = exec_mod
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class EnsureCoreServiceRunningTests(unittest.TestCase):
+    def test_running_instance_returns_without_acquire_or_launch(self):
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value="http://127.0.0.1:18080"
+        ) as find, _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertEqual(result, "http://127.0.0.1:18080")
+        find.assert_called_once_with("svc")
+        acquire.assert_not_called()
+        launch.assert_not_called()
+
+    def test_no_instance_acquire_false_launch_disabled_returns_none(self):
+        acquire = MagicMock(return_value=False)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ) as find, _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc", launch=False)
+
+        self.assertIsNone(result)
+        acquire.assert_called_once_with("svc")
+        launch.assert_not_called()
+        # find_running_endpoint called at the top and again at the bottom.
+        self.assertEqual(find.call_count, 2)
+
+    def test_acquire_true_but_still_no_instance_returns_none(self):
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ), _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertIsNone(result)
+        acquire.assert_called_once_with("svc")
+        launch.assert_called_once_with("svc")
+
+    def test_launch_error_is_swallowed_and_returns_none(self):
+        acquire = MagicMock(return_value=False)
+        launch = MagicMock(side_effect=RuntimeError("no gateway"))
+        with patch.object(
+            runtime, "find_running_endpoint", return_value=None
+        ), _stub_deps(acquire, launch):
+            # Must not raise even though execute() blows up.
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertIsNone(result)
+        launch.assert_called_once_with("svc")
+
+    def test_endpoint_appears_after_launch(self):
+        # First check (top) returns None, second check (bottom) returns endpoint.
+        acquire = MagicMock(return_value=True)
+        launch = MagicMock()
+        with patch.object(
+            runtime,
+            "find_running_endpoint",
+            side_effect=[None, "http://10.0.0.9:7000"],
+        ), _stub_deps(acquire, launch):
+            result = runtime.ensure_core_service_running("svc")
+
+        self.assertEqual(result, "http://10.0.0.9:7000")
+        launch.assert_called_once_with("svc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_low_demand.py
+++ b/tests/test_low_demand.py
@@ -12,6 +12,10 @@ import pytest
 
 low_demand = importlib.import_module("src.core_services.low_demand")
 
+# Real implementation, captured before the autouse fixture stubs it, so the polled
+# detection tests can exercise the genuine _real_workload_present logic.
+_REAL_WORKLOAD_PRESENT = low_demand._real_workload_present
+
 
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch):
@@ -23,6 +27,12 @@ def _reset(monkeypatch):
     )
     # No real workload by default.
     monkeypatch.setattr(low_demand, "_real_workload_present", lambda: False)
+    # Node RAM pool has headroom by default (system-wide + reservation cross-check).
+    monkeypatch.setattr(low_demand, "_iobigdata_has_headroom", lambda: True)
+    # Fresh scheduler state for every test (module singleton).
+    low_demand._state.consecutive_below = 0
+    low_demand._state.last_tick_monotonic = None
+    low_demand._state.running_token = None
     yield
 
 
@@ -144,3 +154,194 @@ def test_run_fallback_once_never_raises(monkeypatch):
 def test_poll_interval_clamped_to_minimum(monkeypatch):
     monkeypatch.setattr(low_demand, "_get_float", lambda k, d: 0.0)
     assert low_demand.poll_interval_seconds() >= 1
+
+
+def test_consecutive_polls_clamped_to_minimum(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: 0.0)
+    assert low_demand.consecutive_polls() >= 1
+
+
+# --- RAM reservation cross-check (Josemi decision #1) -------------------------
+
+
+def test_resources_below_threshold_blocks_when_pool_exhausted(monkeypatch):
+    # System-wide CPU/RAM look fine, but the node's own pool has no headroom.
+    monkeypatch.setattr(
+        low_demand,
+        "_get_float",
+        lambda k, d: {"CPU_MAX_PERCENT": 40.0, "MEM_MAX_PERCENT": 60.0}[k],
+    )
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: 10.0)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 20.0)
+    monkeypatch.setattr(low_demand, "_iobigdata_has_headroom", lambda: False)
+    assert low_demand.resources_below_threshold() is False
+
+
+# --- polled real-workload detection (Josemi decision #3) ---------------------
+
+
+def _install_fake_sql_connection(monkeypatch, ids):
+    """Inject a fake ``src.database.sql_connection`` so we don't import the heavy real
+    module (it pulls in grpc/bee_rpc). ``_real_workload_present`` imports it lazily."""
+    import types
+
+    fake = types.ModuleType("src.database.sql_connection")
+
+    class _FakeSC:
+        def get_all_internal_containers_ids(self):
+            return list(ids)
+
+    fake.SQLConnection = _FakeSC
+    monkeypatch.setitem(sys.modules, "src.database.sql_connection", fake)
+
+
+def test_real_workload_excludes_own_fallback_instance(monkeypatch):
+    monkeypatch.setattr(low_demand, "_real_workload_present", _REAL_WORKLOAD_PRESENT)
+    _install_fake_sql_connection(monkeypatch, ["fallback-tok"])
+    low_demand._state.running_token = "fallback-tok"
+    # Only the fallback's own instance is running -> NOT a real workload.
+    assert low_demand._real_workload_present() is False
+
+
+def test_real_workload_detected_when_other_instance_present(monkeypatch):
+    monkeypatch.setattr(low_demand, "_real_workload_present", _REAL_WORKLOAD_PRESENT)
+    _install_fake_sql_connection(monkeypatch, ["fallback-tok", "real-instance-1"])
+    low_demand._state.running_token = "fallback-tok"
+    # A different (real) instance is running alongside the fallback -> busy.
+    assert low_demand._real_workload_present() is True
+
+
+# --- preemption: ALWAYS STOP, never pause (Josemi decision #2) ---------------
+
+
+def test_stop_running_fallback_calls_stop_instance(monkeypatch):
+    import types
+
+    calls = {}
+
+    def _fake_stop(token):
+        calls["token"] = token
+        return 0
+
+    # Inject a fake src.manager.manager so we don't import the heavy real module and
+    # can assert the STOP path (there is no pause primitive to call).
+    fake_mgr = types.ModuleType("src.manager.manager")
+    fake_mgr.stop_instance = _fake_stop
+    monkeypatch.setitem(sys.modules, "src.manager.manager", fake_mgr)
+
+    low_demand._state.running_token = "tok-123"
+    low_demand._stop_running_fallback()
+
+    assert calls == {"token": "tok-123"}
+    # Token cleared after stopping so we don't try to stop it again.
+    assert low_demand._state.running_token is None
+
+
+# --- scheduler_tick: hysteresis + preemption ---------------------------------
+
+
+def test_scheduler_tick_starts_only_after_hysteresis(monkeypatch):
+    # Idle + under threshold every tick; cadence gate disabled (poll interval 0).
+    monkeypatch.setattr(low_demand, "poll_interval_seconds", lambda: 0)
+    monkeypatch.setattr(low_demand, "consecutive_polls", lambda: 3)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: False)
+
+    launches = {"n": 0}
+    monkeypatch.setattr(low_demand, "run_fallback_once", lambda: launches.__setitem__("n", launches["n"] + 1))
+
+    # First two ticks accumulate hysteresis but do NOT start.
+    low_demand.scheduler_tick()
+    assert launches["n"] == 0
+    assert low_demand._state.consecutive_below == 1
+    low_demand.scheduler_tick()
+    assert launches["n"] == 0
+    assert low_demand._state.consecutive_below == 2
+
+    # Third consecutive clean poll crosses the hysteresis threshold -> start.
+    low_demand.scheduler_tick()
+    assert launches["n"] == 1
+    assert low_demand._state.consecutive_below == 3
+
+
+def test_scheduler_tick_no_start_when_over_threshold(monkeypatch):
+    monkeypatch.setattr(low_demand, "poll_interval_seconds", lambda: 0)
+    monkeypatch.setattr(low_demand, "consecutive_polls", lambda: 1)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: False)
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: False)
+
+    def _must_not_launch():  # pragma: no cover
+        raise AssertionError("must not start the fallback when over threshold")
+
+    monkeypatch.setattr(low_demand, "run_fallback_once", _must_not_launch)
+
+    stops = {"n": 0}
+    monkeypatch.setattr(low_demand, "_stop_running_fallback", lambda: stops.__setitem__("n", stops["n"] + 1))
+
+    # Pretend some hysteresis had accumulated; over-threshold must reset it.
+    low_demand._state.consecutive_below = 5
+    low_demand.scheduler_tick()
+
+    assert stops["n"] == 1
+    assert low_demand._state.consecutive_below == 0
+
+
+def test_scheduler_tick_real_request_preempts_and_stops(monkeypatch):
+    # Under threshold but a real request is present -> STOP (never start/pause).
+    monkeypatch.setattr(low_demand, "poll_interval_seconds", lambda: 0)
+    monkeypatch.setattr(low_demand, "consecutive_polls", lambda: 1)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: True)
+
+    def _must_not_launch():  # pragma: no cover
+        raise AssertionError("must not start the fallback while a real request is present")
+
+    monkeypatch.setattr(low_demand, "run_fallback_once", _must_not_launch)
+
+    stops = {"n": 0}
+    monkeypatch.setattr(low_demand, "_stop_running_fallback", lambda: stops.__setitem__("n", stops["n"] + 1))
+
+    low_demand._state.consecutive_below = 2
+    low_demand.scheduler_tick()
+
+    assert stops["n"] == 1
+    assert low_demand._state.consecutive_below == 0
+
+
+def test_scheduler_tick_respects_poll_interval_cadence(monkeypatch):
+    # A large poll interval means a second immediate tick is a no-op.
+    monkeypatch.setattr(low_demand, "poll_interval_seconds", lambda: 3600)
+    monkeypatch.setattr(low_demand, "consecutive_polls", lambda: 1)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: False)
+
+    launches = {"n": 0}
+    monkeypatch.setattr(low_demand, "run_fallback_once", lambda: launches.__setitem__("n", launches["n"] + 1))
+
+    low_demand.scheduler_tick()  # runs (first ever tick)
+    low_demand.scheduler_tick()  # gated by cadence -> no-op
+    assert launches["n"] == 1
+
+
+def test_scheduler_tick_noop_when_disabled(monkeypatch):
+    monkeypatch.setattr(low_demand, "is_enabled", lambda: False)
+
+    def _boom():  # pragma: no cover
+        raise AssertionError("disabled tick must do nothing")
+
+    monkeypatch.setattr(low_demand, "resources_below_threshold", _boom)
+    monkeypatch.setattr(low_demand, "run_fallback_once", _boom)
+    monkeypatch.setattr(low_demand, "_stop_running_fallback", _boom)
+
+    low_demand.scheduler_tick()  # returns immediately, nothing invoked
+
+
+def test_scheduler_tick_never_raises(monkeypatch):
+    monkeypatch.setattr(low_demand, "poll_interval_seconds", lambda: 0)
+
+    def _boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(low_demand, "resources_below_threshold", _boom)
+    # Must swallow and return None, never propagate into the manager loop.
+    assert low_demand.scheduler_tick() is None

--- a/tests/test_low_demand.py
+++ b/tests/test_low_demand.py
@@ -1,0 +1,146 @@
+"""Unit tests for the low-demand fallback scheduler scaffold.
+
+These tests mock the resource readings and the launch path so nothing real is
+started and no network is touched. They cover the config-threshold reading and
+the ``should_run_fallback`` decision logic.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+low_demand = importlib.import_module("src.core_services.low_demand")
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    """Default happy-path stubs; individual tests override as needed."""
+    # Enabled + a configured id by default.
+    monkeypatch.setattr(low_demand, "is_enabled", lambda: True)
+    monkeypatch.setattr(
+        low_demand, "get_core_service_id", lambda name: "deadbeef" if name else None
+    )
+    # No real workload by default.
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: False)
+    yield
+
+
+# --- threshold reading -------------------------------------------------------
+
+
+def test_resources_below_threshold_true_when_under(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: {"CPU_MAX_PERCENT": 40.0, "MEM_MAX_PERCENT": 60.0}[k])
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: 10.0)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 20.0)
+    assert low_demand.resources_below_threshold() is True
+
+
+def test_resources_below_threshold_false_when_cpu_over(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: {"CPU_MAX_PERCENT": 40.0, "MEM_MAX_PERCENT": 60.0}[k])
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: 90.0)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 20.0)
+    assert low_demand.resources_below_threshold() is False
+
+
+def test_resources_below_threshold_false_when_mem_over(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: {"CPU_MAX_PERCENT": 40.0, "MEM_MAX_PERCENT": 60.0}[k])
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: 10.0)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 99.0)
+    assert low_demand.resources_below_threshold() is False
+
+
+def test_resources_below_threshold_boundary_is_inclusive(monkeypatch):
+    # Exactly at the threshold counts as "below" (<=).
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: {"CPU_MAX_PERCENT": 40.0, "MEM_MAX_PERCENT": 60.0}[k])
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: 40.0)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 60.0)
+    assert low_demand.resources_below_threshold() is True
+
+
+def test_resources_below_threshold_fail_closed_when_reading_missing(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: 50.0)
+    monkeypatch.setattr(low_demand, "_current_cpu_percent", lambda: None)
+    monkeypatch.setattr(low_demand, "_current_mem_percent", lambda: 10.0)
+    assert low_demand.resources_below_threshold() is False
+
+
+# --- should_run_fallback -----------------------------------------------------
+
+
+def test_should_run_true_when_idle_and_under_threshold(monkeypatch):
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    assert low_demand.should_run_fallback() is True
+
+
+def test_should_run_false_when_disabled(monkeypatch):
+    monkeypatch.setattr(low_demand, "is_enabled", lambda: False)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    assert low_demand.should_run_fallback() is False
+
+
+def test_should_run_false_when_no_id_configured(monkeypatch):
+    monkeypatch.setattr(low_demand, "get_core_service_id", lambda name: None)
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    assert low_demand.should_run_fallback() is False
+
+
+def test_should_run_false_when_over_threshold(monkeypatch):
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: False)
+    assert low_demand.should_run_fallback() is False
+
+
+def test_should_run_false_when_real_workload_present(monkeypatch):
+    monkeypatch.setattr(low_demand, "resources_below_threshold", lambda: True)
+    monkeypatch.setattr(low_demand, "_real_workload_present", lambda: True)
+    assert low_demand.should_run_fallback() is False
+
+
+# --- run_fallback_once (launch path mocked) ----------------------------------
+
+
+def test_run_fallback_once_launches_when_should_run(monkeypatch):
+    monkeypatch.setattr(low_demand, "should_run_fallback", lambda: True)
+    calls = {}
+
+    def _fake_ensure(service_id, *, launch=True):
+        calls["service_id"] = service_id
+        calls["launch"] = launch
+        return "http://1.2.3.4:5000"
+
+    # ensure_core_service_running is imported inside the function, so patch the source module.
+    runtime = importlib.import_module("src.core_services.runtime")
+    monkeypatch.setattr(runtime, "ensure_core_service_running", _fake_ensure)
+
+    endpoint = low_demand.run_fallback_once()
+    assert endpoint == "http://1.2.3.4:5000"
+    assert calls == {"service_id": "deadbeef", "launch": True}
+
+
+def test_run_fallback_once_noop_when_should_not_run(monkeypatch):
+    monkeypatch.setattr(low_demand, "should_run_fallback", lambda: False)
+
+    runtime = importlib.import_module("src.core_services.runtime")
+
+    def _boom(*a, **k):  # pragma: no cover - must never be called
+        raise AssertionError("ensure_core_service_running must not be called")
+
+    monkeypatch.setattr(runtime, "ensure_core_service_running", _boom)
+    assert low_demand.run_fallback_once() is None
+
+
+def test_run_fallback_once_never_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(low_demand, "should_run_fallback", _boom)
+    # Must swallow and return None, never propagate.
+    assert low_demand.run_fallback_once() is None
+
+
+# --- misc helpers ------------------------------------------------------------
+
+
+def test_poll_interval_clamped_to_minimum(monkeypatch):
+    monkeypatch.setattr(low_demand, "_get_float", lambda k, d: 0.0)
+    assert low_demand.poll_interval_seconds() >= 1

--- a/tests/test_publisher_source_registration.py
+++ b/tests/test_publisher_source_registration.py
@@ -1,0 +1,175 @@
+"""Tests for the four-level source registration in ``nodo publish``.
+
+Covers :func:`src.publisher.publisher._announce_source_registration` (the
+AUTO_PUBLISH_TX / instance-link / web-page-link / manual-message decision) and
+:func:`_submit_source_via_instance_api` (the provisional auto-submit payload).
+
+Follows the repo convention of guarding the import so the suite skips cleanly when
+the runtime dependencies (bee_rpc, mnemonic, protos, a loadable config) are absent.
+"""
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+IMPORT_ERROR = None
+try:
+    from src.publisher import publisher
+except Exception as import_exc:  # pragma: no cover - environment-dependent
+    IMPORT_ERROR = import_exc
+    publisher = None  # type: ignore[assignment]
+
+
+def _settings(**overrides):
+    """Minimal settings dict shaped like ``_get_publisher_settings`` output."""
+    hash_spec = MagicMock()
+    hash_spec.id_bytes.hex.return_value = "abcd"
+    base = {
+        "hash_spec": hash_spec,
+        "source_application_web_page": "https://web.example/source?tab=add",
+        "auto_publish_tx": False,
+        "content_format": ".grpcbb",
+        "raw_format": ".celaut",
+        "timeout_s": 5,
+        "max_retry": 1,
+        "backoff_s": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _announce(settings):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        publisher._announce_source_registration(
+            settings,
+            service_id="svcid",
+            content_hash="chash",
+            manifest_url="https://raw.example/manifest",
+        )
+    return buf.getvalue()
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class AnnounceSourceRegistrationTests(unittest.TestCase):
+    # ---- Level 1: AUTO_PUBLISH_TX + running instance -> auto submit ----
+    def test_level1_auto_submit_success_skips_link(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+             patch.object(publisher, "_submit_source_via_instance_api", return_value=True) as submit, \
+             patch.object(publisher, "_print_click_to_add") as link, \
+             patch.object(publisher, "ConfigManager") as cfg:
+            cfg.return_value.get.return_value = "word word word"
+            out = _announce(_settings(auto_publish_tx=True))
+
+        submit.assert_called_once()
+        # The node wallet seed is forwarded to the instance signer.
+        self.assertEqual(submit.call_args.kwargs["seed"], "word word word")
+        self.assertEqual(submit.call_args.kwargs["file_hash"], "svcid")
+        link.assert_not_called()
+        self.assertIn("submitted directly", out)
+
+    def test_level1_missing_seed_falls_back_to_instance_link(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+             patch.object(publisher, "_submit_source_via_instance_api") as submit, \
+             patch.object(publisher, "_print_click_to_add") as link, \
+             patch.object(publisher, "ConfigManager") as cfg:
+            cfg.return_value.get.return_value = ""  # empty WALLET_MNEMONIC
+            _announce(_settings(auto_publish_tx=True))
+
+        submit.assert_not_called()
+        link.assert_called_once()
+        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+
+    def test_level1_submit_failure_falls_back_to_instance_link(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+             patch.object(publisher, "_submit_source_via_instance_api", return_value=False), \
+             patch.object(publisher, "_print_click_to_add") as link, \
+             patch.object(publisher, "ConfigManager") as cfg:
+            cfg.return_value.get.return_value = "seed here"
+            _announce(_settings(auto_publish_tx=True))
+
+        link.assert_called_once()
+        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+
+    # ---- Level 2: running instance, auto disabled -> instance link ----
+    def test_level2_instance_link_when_auto_disabled(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+             patch.object(publisher, "_submit_source_via_instance_api") as submit, \
+             patch.object(publisher, "_print_click_to_add") as link:
+            _announce(_settings(auto_publish_tx=False))
+
+        submit.assert_not_called()
+        link.assert_called_once()
+        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+
+    # ---- Level 3: no instance, web page configured -> web-page link ----
+    def test_level3_web_page_link_when_no_instance(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value=None), \
+             patch.object(publisher, "_print_click_to_add") as link:
+            _announce(_settings(auto_publish_tx=True))  # auto on but no instance
+
+        link.assert_called_once()
+        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
+
+    # ---- Level 4: no instance, no web page -> manual message ----
+    def test_level4_manual_message_when_nothing_configured(self):
+        with patch.object(publisher, "_resolve_source_application_endpoint", return_value=None), \
+             patch.object(publisher, "_print_click_to_add") as link:
+            out = _announce(_settings(source_application_web_page=""))
+
+        link.assert_not_called()
+        self.assertIn("Register the source manually", out)
+
+
+@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
+class SubmitSourceViaInstanceApiTests(unittest.TestCase):
+    def _call(self, request_mock, **overrides):
+        kwargs = dict(
+            seed="node seed",
+            file_hash="svcid",
+            content_hash="chash",
+            hash_function_id="abcd",
+            manifest_url="https://raw.example/manifest",
+            content_format=".grpcbb",
+            raw_format=".celaut",
+            timeout_s=5,
+            max_retry=1,
+            backoff_s=0,
+        )
+        kwargs.update(overrides)
+        with patch.object(publisher, "_request_with_retry", request_mock):
+            return publisher._submit_source_via_instance_api("http://10.0.0.2:9000/", **kwargs)
+
+    def test_posts_to_publish_route_with_seed_and_returns_true(self):
+        request_mock = MagicMock(return_value=MagicMock())
+        ok = self._call(request_mock)
+
+        self.assertTrue(ok)
+        args, kwargs = request_mock.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(args[1], "http://10.0.0.2:9000/publish")  # trailing slash collapsed
+        payload = kwargs["json"]
+        self.assertEqual(payload["seed"], "node seed")
+        self.assertEqual(payload["fileHash"], "svcid")
+        # raw != content -> raw fields present
+        self.assertEqual(payload["rawFormat"], ".celaut")
+        self.assertEqual(payload["rawHash"], "svcid")
+
+    def test_omits_raw_fields_when_formats_match(self):
+        request_mock = MagicMock(return_value=MagicMock())
+        self._call(request_mock, raw_format=".grpcbb", content_format=".grpcbb")
+        payload = request_mock.call_args.kwargs["json"]
+        self.assertNotIn("rawFormat", payload)
+        self.assertNotIn("rawHash", payload)
+
+    def test_returns_false_on_publisher_error(self):
+        request_mock = MagicMock(side_effect=publisher.PublisherError("boom"))
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ok = self._call(request_mock)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publisher_source_registration.py
+++ b/tests/test_publisher_source_registration.py
@@ -1,8 +1,8 @@
 """Tests for the four-level source registration in ``nodo publish``.
 
 Covers :func:`src.publisher.publisher._announce_source_registration` (the
-AUTO_PUBLISH_TX / instance-link / web-page-link / manual-message decision) and
-:func:`_submit_source_via_instance_api` (the provisional auto-submit payload).
+AUTO_PUBLISH_TX / web-page-link / manual-message decision) and
+:func:`_submit_source_via_instance_api` (the confirmed ``POST /api/sources`` payload).
 
 Follows the repo convention of guarding the import so the suite skips cleanly when
 the runtime dependencies (bee_rpc, mnemonic, protos, a loadable config) are absent.
@@ -53,47 +53,48 @@ def _announce(settings):
 
 @unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
 class AnnounceSourceRegistrationTests(unittest.TestCase):
-    # ---- Level 1: AUTO_PUBLISH_TX + running instance -> auto submit ----
+    # ---- Level 1: AUTO_PUBLISH_TX + running instance + profile box -> auto submit ----
     def test_level1_auto_submit_success_skips_link(self):
         with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
              patch.object(publisher, "_submit_source_via_instance_api", return_value=True) as submit, \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
-            cfg.return_value.get.return_value = "word word word"
+            cfg.return_value.get.return_value = "profilebox64hex"
             out = _announce(_settings(auto_publish_tx=True))
 
         submit.assert_called_once()
-        # The node wallet seed is forwarded to the instance signer.
-        self.assertEqual(submit.call_args.kwargs["seed"], "word word word")
+        # The node's PROFILE box id is forwarded as the opinion author; no seed over HTTP.
+        self.assertEqual(submit.call_args.kwargs["main_box_id"], "profilebox64hex")
         self.assertEqual(submit.call_args.kwargs["file_hash"], "svcid")
+        self.assertNotIn("seed", submit.call_args.kwargs)
         link.assert_not_called()
         self.assertIn("submitted directly", out)
 
-    def test_level1_missing_seed_falls_back_to_instance_link(self):
+    def test_level1_missing_profile_box_falls_back_to_web_link(self):
         with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
              patch.object(publisher, "_submit_source_via_instance_api") as submit, \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
-            cfg.return_value.get.return_value = ""  # empty WALLET_MNEMONIC
+            cfg.return_value.get.return_value = ""  # empty SOURCE_PROFILE_BOX_ID
             _announce(_settings(auto_publish_tx=True))
 
         submit.assert_not_called()
         link.assert_called_once()
-        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
-    def test_level1_submit_failure_falls_back_to_instance_link(self):
+    def test_level1_submit_failure_falls_back_to_web_link(self):
         with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
              patch.object(publisher, "_submit_source_via_instance_api", return_value=False), \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
-            cfg.return_value.get.return_value = "seed here"
+            cfg.return_value.get.return_value = "profilebox64hex"
             _announce(_settings(auto_publish_tx=True))
 
         link.assert_called_once()
-        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
-    # ---- Level 2: running instance, auto disabled -> instance link ----
-    def test_level2_instance_link_when_auto_disabled(self):
+    # ---- Level 2: running instance, auto disabled -> web-page link (NOT the instance) ----
+    def test_level2_web_link_when_auto_disabled(self):
         with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
              patch.object(publisher, "_submit_source_via_instance_api") as submit, \
              patch.object(publisher, "_print_click_to_add") as link:
@@ -101,7 +102,8 @@ class AnnounceSourceRegistrationTests(unittest.TestCase):
 
         submit.assert_not_called()
         link.assert_called_once()
-        self.assertEqual(link.call_args.args[0], "http://10.0.0.2:9000")
+        # The instance serves only /api + /mcp; the prefill link must target the web app.
+        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
     # ---- Level 3: no instance, web page configured -> web-page link ----
     def test_level3_web_page_link_when_no_instance(self):
@@ -124,9 +126,17 @@ class AnnounceSourceRegistrationTests(unittest.TestCase):
 
 @unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
 class SubmitSourceViaInstanceApiTests(unittest.TestCase):
+    @staticmethod
+    def _response(body):
+        """A stand-in for _request_with_retry's return: an object with .content bytes."""
+        import json as _json
+        resp = MagicMock()
+        resp.content = _json.dumps(body).encode("utf-8")
+        return resp
+
     def _call(self, request_mock, **overrides):
         kwargs = dict(
-            seed="node seed",
+            main_box_id="profilebox64hex",
             file_hash="svcid",
             content_hash="chash",
             hash_function_id="abcd",
@@ -141,27 +151,35 @@ class SubmitSourceViaInstanceApiTests(unittest.TestCase):
         with patch.object(publisher, "_request_with_retry", request_mock):
             return publisher._submit_source_via_instance_api("http://10.0.0.2:9000/", **kwargs)
 
-    def test_posts_to_publish_route_with_seed_and_returns_true(self):
-        request_mock = MagicMock(return_value=MagicMock())
+    def test_posts_to_api_sources_with_source_entry_and_returns_true(self):
+        request_mock = MagicMock(return_value=self._response({"submitted": True, "txId": "tx1"}))
         ok = self._call(request_mock)
 
         self.assertTrue(ok)
         args, kwargs = request_mock.call_args
         self.assertEqual(args[0], "POST")
-        self.assertEqual(args[1], "http://10.0.0.2:9000/publish")  # trailing slash collapsed
+        self.assertEqual(args[1], "http://10.0.0.2:9000/api/sources")  # trailing slash collapsed
         payload = kwargs["json"]
-        self.assertEqual(payload["seed"], "node seed")
+        self.assertEqual(payload["mainBoxId"], "profilebox64hex")
         self.assertEqual(payload["fileHash"], "svcid")
-        # raw != content -> raw fields present
-        self.assertEqual(payload["rawFormat"], ".celaut")
-        self.assertEqual(payload["rawHash"], "svcid")
+        self.assertNotIn("seed", payload)  # the mnemonic is never sent over HTTP
+        entry = payload["sourceEntry"]
+        self.assertEqual(entry["hashFunctionId"], "abcd")
+        self.assertEqual(entry["contentHash"], "chash")
+        self.assertEqual(entry["rawFormat"], ".celaut")
+        self.assertEqual(entry["urlLink"], "https://raw.example/manifest")
+        self.assertIs(entry["isChunked"], True)
 
-    def test_omits_raw_fields_when_formats_match(self):
-        request_mock = MagicMock(return_value=MagicMock())
-        self._call(request_mock, raw_format=".grpcbb", content_format=".grpcbb")
-        payload = request_mock.call_args.kwargs["json"]
-        self.assertNotIn("rawFormat", payload)
-        self.assertNotIn("rawHash", payload)
+    def test_unsigned_response_returns_false(self):
+        # An unsigned-mode instance returns an unsigned tx: not a real submit.
+        request_mock = MagicMock(
+            return_value=self._response({"submitted": False, "unsignedTransaction": {"inputs": []}})
+        )
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ok = self._call(request_mock)
+        self.assertFalse(ok)
+        self.assertIn("unsigned mode", buf.getvalue())
 
     def test_returns_false_on_publisher_error(self):
         request_mock = MagicMock(side_effect=publisher.PublisherError("boom"))

--- a/tests/test_publisher_source_registration.py
+++ b/tests/test_publisher_source_registration.py
@@ -53,15 +53,16 @@ def _announce(settings):
 
 @unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
 class AnnounceSourceRegistrationTests(unittest.TestCase):
-    # ---- Level 1: AUTO_PUBLISH_TX + running instance + profile box -> auto submit ----
+    # ---- Level 1: AUTO_PUBLISH_TX + profile box -> auto-launch seed instance + submit ----
     def test_level1_auto_submit_success_skips_link(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+        with patch.object(publisher, "_ensure_seed_mode_source_application", return_value="http://10.0.0.2:8080") as ensure, \
              patch.object(publisher, "_submit_source_via_instance_api", return_value=True) as submit, \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
             cfg.return_value.get.return_value = "profilebox64hex"
             out = _announce(_settings(auto_publish_tx=True))
 
+        ensure.assert_called_once()  # the node auto-launches a seed-mode instance
         submit.assert_called_once()
         # The node's PROFILE box id is forwarded as the opinion author; no seed over HTTP.
         self.assertEqual(submit.call_args.kwargs["main_box_id"], "profilebox64hex")
@@ -71,19 +72,32 @@ class AnnounceSourceRegistrationTests(unittest.TestCase):
         self.assertIn("submitted directly", out)
 
     def test_level1_missing_profile_box_falls_back_to_web_link(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+        with patch.object(publisher, "_ensure_seed_mode_source_application") as ensure, \
              patch.object(publisher, "_submit_source_via_instance_api") as submit, \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
             cfg.return_value.get.return_value = ""  # empty SOURCE_PROFILE_BOX_ID
             _announce(_settings(auto_publish_tx=True))
 
+        ensure.assert_not_called()  # no author identity -> don't even launch
         submit.assert_not_called()
         link.assert_called_once()
         self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
+    def test_level1_no_seed_instance_falls_back_to_web_link(self):
+        with patch.object(publisher, "_ensure_seed_mode_source_application", return_value=None), \
+             patch.object(publisher, "_submit_source_via_instance_api") as submit, \
+             patch.object(publisher, "_print_click_to_add") as link, \
+             patch.object(publisher, "ConfigManager") as cfg:
+            cfg.return_value.get.return_value = "profilebox64hex"
+            _announce(_settings(auto_publish_tx=True))
+
+        submit.assert_not_called()  # couldn't launch a seed-mode instance
+        link.assert_called_once()
+        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
+
     def test_level1_submit_failure_falls_back_to_web_link(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+        with patch.object(publisher, "_ensure_seed_mode_source_application", return_value="http://10.0.0.2:8080"), \
              patch.object(publisher, "_submit_source_via_instance_api", return_value=False), \
              patch.object(publisher, "_print_click_to_add") as link, \
              patch.object(publisher, "ConfigManager") as cfg:
@@ -93,32 +107,23 @@ class AnnounceSourceRegistrationTests(unittest.TestCase):
         link.assert_called_once()
         self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
-    # ---- Level 2: running instance, auto disabled -> web-page link (NOT the instance) ----
+    # ---- Level 2: auto disabled -> web-page link, never launches/submits ----
     def test_level2_web_link_when_auto_disabled(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value="http://10.0.0.2:9000"), \
+        with patch.object(publisher, "_ensure_seed_mode_source_application") as ensure, \
              patch.object(publisher, "_submit_source_via_instance_api") as submit, \
              patch.object(publisher, "_print_click_to_add") as link:
             _announce(_settings(auto_publish_tx=False))
 
+        ensure.assert_not_called()
         submit.assert_not_called()
         link.assert_called_once()
         # The instance serves only /api + /mcp; the prefill link must target the web app.
         self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
 
-    # ---- Level 3: no instance, web page configured -> web-page link ----
-    def test_level3_web_page_link_when_no_instance(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value=None), \
-             patch.object(publisher, "_print_click_to_add") as link:
-            _announce(_settings(auto_publish_tx=True))  # auto on but no instance
-
-        link.assert_called_once()
-        self.assertEqual(link.call_args.args[0], "https://web.example/source?tab=add")
-
-    # ---- Level 4: no instance, no web page -> manual message ----
+    # ---- Level 4: nothing configured -> manual message ----
     def test_level4_manual_message_when_nothing_configured(self):
-        with patch.object(publisher, "_resolve_source_application_endpoint", return_value=None), \
-             patch.object(publisher, "_print_click_to_add") as link:
-            out = _announce(_settings(source_application_web_page=""))
+        with patch.object(publisher, "_print_click_to_add") as link:
+            out = _announce(_settings(auto_publish_tx=False, source_application_web_page=""))
 
         link.assert_not_called()
         self.assertIn("Register the source manually", out)


### PR DESCRIPTION
## What

`nodo publish` resolves **how** to register a freshly-published source, and — when opted in — publishes the source opinion on-chain itself via an auto-launched, seed-signing `source-application` instance.

| Level | Condition | Behaviour |
|-------|-----------|-----------|
| **1** | `AUTO_PUBLISH_TX` on + `SOURCE_PROFILE_BOX_ID` set + a configured `source-application` core service | The node **auto-launches** the source-application in seed mode (wallet injected into its env) if one isn't already running, then publishes the FILE_SOURCE opinion via **`POST /api/sources`**. The instance signs + submits the tx itself. No click. |
| **2** | auto off / auto-submit unavailable, web page set | Prefilled click-to-add link on the **web app** (a running instance serves only `/api` + `/mcp` JSON). |
| **3** | no instance, `SOURCE_APPLICATION_WEB_PAGE` set | Same prefilled click-to-add link *(pre-existing behaviour)*. |
| **4** | nothing usable | Manual-registration message (file hash + content hash + manifest URL). |

## ✅ Open questions resolved (verified against the deployed service)

Josemi/Nate confirmed the three questions; each was checked against the real `source-application` service code (`.service/server-http.mjs`, `mcp/writes.mjs`, `mcp/lib.mjs`) and the provisional guesses corrected:

1. **Write contract.** Real route is **`POST /api/sources`** with `{mainBoxId, fileHash, sourceEntry}` where `sourceEntry = {hashFunctionId, contentFormat, contentHash, rawFormat, urlLink, isChunked}` — *not* `<endpoint>/publish` with a flat payload. Reads are **`GET /api/sources?hash=<id>`** on a running instance (the static web app has no `/api`), *not* `<web_page>/sources/<id>`. Port **8080**. Success is gated on the response's `submitted` flag (`{submitted:true,txId}` vs an unsigned-mode `{submitted:false,unsignedTransaction}`).

2. **Seed model.** Seed-signer is the intended flow, and **the node now auto-launches the instance in seed mode** — injecting `SOURCE_SIGNER_MODE=seed` + `SOURCE_MNEMONIC` (`ledgers.ergo.WALLET_MNEMONIC`) + `SOURCE_NODE_URI` (`ledgers.ergo.NODE_URL`) into the launched microVM's environment via `execute()`'s existing `Configuration.environment_variables`. The mnemonic is **never** sent over HTTP. Level 1 carries the node's reputation **PROFILE box id** (`publisher.SOURCE_PROFILE_BOX_ID`) as the opinion author.

3. **Level-2 URL.** A running instance serves only `/api` + `/mcp` JSON — never the prefill form — so a bare `http://ip:port?tab=add…` would **404**. The manual link now always targets the configured web app (`SOURCE_APPLICATION_WEB_PAGE`).

## Remaining setup / caveats
- **PROFILE box provisioning (one-time).** `POST /api/profile` in seed mode returns a `txId`, not an immediately-usable box id (the box exists only after the tx confirms), so minting inline on every publish isn't viable. Mint a profile once and set `publisher.SOURCE_PROFILE_BOX_ID`.
- **Already-running instance.** `envs` apply only to a *newly launched* instance. If a source-application instance is already running (e.g. someone started it unsigned), its env is used as-is — the node won't relaunch it to switch modes, so it returns an unsigned tx and the publisher falls back to a link.

## Verification
- ✅ `tests/test_publisher_source_registration.py` — four levels, auto-launch + seed-env path, confirmed `POST /api/sources` payload, unsigned-response handling. **9/9 pass** (stubbed runtime deps).
- ✅ `tests/test_core_services_runtime.py` — launch-signature tests updated for the new `envs` kwarg (pass; one unrelated case needs the real protobuf, skipped on the dev box).
- ✅ `py_compile` clean on all touched modules.

Supersedes agenticaihome/nodo#1. Still stacked on #120/#121 (diff-vs-`stable` shows those until they merge).
