### PR TITLE
feat(instances): persist an instance's launch env vars in local_instances

### DIFF
--- a/src/database/migrate.py
+++ b/src/database/migrate.py
@@ -106,7 +106,8 @@ def create_tables(cursor):
                 disk_space INTEGER,
                 serialized_instance TEXT,
                 service_id TEXT,
-                virtualizer TEXT DEFAULT NULL
+                virtualizer TEXT DEFAULT NULL,
+                envs TEXT DEFAULT NULL
             )
         ''',
         "delegated_instances": '''
@@ -161,6 +162,29 @@ def create_tables(cursor):
             print(f"Created or updated '{table_name}' table.")
         except sqlite3.Error as e:
             print(f"Error creating '{table_name}' table: {e}")
+
+    # Additive column migrations for databases created before a column existed.
+    # `CREATE TABLE IF NOT EXISTS` never alters an existing table, so new columns
+    # must be back-filled here. Each entry is idempotent (skipped when present).
+    ensure_columns(cursor, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+
+
+def ensure_columns(cursor, table_name: str, columns: dict) -> None:
+    """Add any missing ``columns`` to ``table_name`` (idempotent).
+
+    ``columns`` maps column name -> its SQL declaration (e.g. ``"TEXT DEFAULT NULL"``).
+    A column already present is left untouched. Safe to run on every startup.
+    """
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    existing = {row[1] for row in cursor.fetchall()}  # row[1] = column name
+    for column, declaration in columns.items():
+        if column in existing:
+            continue
+        try:
+            cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN {column} {declaration}")
+            print(f"Added column '{column}' to '{table_name}' table.")
+        except sqlite3.Error as e:
+            print(f"Error adding column '{column}' to '{table_name}': {e}")
 
 def migrate():
     """Run the migration script."""

--- a/src/database/sql_connection.py
+++ b/src/database/sql_connection.py
@@ -291,6 +291,7 @@ class SQLConnection(metaclass=Singleton):
         service_id: str,
         virtualizer: Optional[str] = None,
         disk_space: Optional[int] = None,
+        envs: Optional[str] = None,
     ):
         """
         Adds an internal container to the database.
@@ -305,15 +306,36 @@ class SQLConnection(metaclass=Singleton):
             service_id (str): Service id
             virtualizer (Optional[str]): Virtualizer backend name
             disk_space (Optional[int]): Disk resource limit for the instance
+            envs (Optional[str]): JSON object of the environment variables the
+                instance was launched with (e.g. signer mode/seed for a
+                source-application), so the node can later tell how it was configured.
         """
         gas = str(gas)
         if virtualizer is None:
             virtualizer = env_manager.get("virtualizers.DEFAULT_VIRTUALIZER", "docker")
         self._execute('''
-            INSERT INTO local_instances (id, name, ip, father_id, gas, mem_limit, disk_space, serialized_instance, service_id, virtualizer)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ''', (container_id, name, container_ip, father_id, gas, 0, disk_space, serialized_instance, service_id, virtualizer))
+            INSERT INTO local_instances (id, name, ip, father_id, gas, mem_limit, disk_space, serialized_instance, service_id, virtualizer, envs)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (container_id, name, container_ip, father_id, gas, 0, disk_space, serialized_instance, service_id, virtualizer, envs))
         log.LOGGER(f'Saved instance {container_id} ({name}) as dependency of {father_id}')
+
+    def get_local_instance_envs(self, id: str) -> Optional[str]:
+        """
+        Retrieves the stored launch environment variables (raw JSON text) for a
+        local instance, or ``None`` when the instance is unknown or was recorded
+        without envs.
+
+        Args:
+            id (str): The id of the internal container.
+
+        Returns:
+            Optional[str]: The JSON-encoded env map, or ``None``.
+        """
+        cursor = self._execute('''
+            SELECT envs FROM local_instances WHERE id = ?
+        ''', (id,))
+        result = cursor.fetchone()
+        return result[0] if result and result[0] is not None else None
 
     def update_sys_req(
         self,

--- a/src/gateway/launcher/local_execution/local_execution.py
+++ b/src/gateway/launcher/local_execution/local_execution.py
@@ -1,3 +1,4 @@
+import json
 import traceback
 from typing import Optional, Callable, List, Dict
 
@@ -22,6 +23,24 @@ from src.virtualizers.firewall import resolve_slot_transport_protocols
 
 sc = SQLConnection()
 env_manager = ConfigManager()
+
+
+def _serialize_envs(config: Optional[celaut.Configuration]) -> Optional[str]:
+    """Serialize a Configuration's ``environment_variables`` map to JSON text.
+
+    The instance is launched with these envs (see ``execute()``), so persisting them
+    lets the node later tell how an instance was configured — e.g. whether a
+    source-application was started as a seed signer (``SOURCE_SIGNER_MODE=seed``).
+    Values are protobuf ``bytes``; they are decoded as UTF-8 (env vars are text).
+    Returns ``None`` when there are no env vars, so the DB column stays NULL.
+    """
+    if config is None or not config.environment_variables:
+        return None
+    envs = {
+        key: value.decode("utf-8", errors="replace")
+        for key, value in config.environment_variables.items()
+    }
+    return json.dumps(envs, sort_keys=True) if envs else None
 
 
 _INTERFACE_PREFIX_PRIORITY = (
@@ -292,9 +311,10 @@ def local_execution(
         serialized_instance=instance.SerializeToString(),
         virtualizer=configured_virtualizer,
         system_requirements_range=celaut_pb2.ModifyServiceSystemResourcesInput(
-                min_sysreq=initial_system_resources, 
+                min_sysreq=initial_system_resources,
                 max_sysreq=initial_system_resources
-            )
+            ),
+        envs=_serialize_envs(config),
         )
     log.LOGGER(
         f"Instance provisioned in DB: vmachine_id={vmachine_id}, virtualizer={configured_virtualizer}, "

--- a/src/manager/manager.py
+++ b/src/manager/manager.py
@@ -484,7 +484,8 @@ def provision_vmachine(
         initial_gas_amount: Optional[int],
         serialized_instance: str,
         virtualizer: Optional[str] = None,
-        system_requirements_range: celaut_pb2.ModifyServiceSystemResourcesInput = None
+        system_requirements_range: celaut_pb2.ModifyServiceSystemResourcesInput = None,
+        envs: Optional[str] = None,
 ):
     disk_space = None
     if system_requirements_range and system_requirements_range.max_sysreq:
@@ -506,6 +507,7 @@ def provision_vmachine(
         service_id=service_id,
         virtualizer=virtualizer,
         disk_space=disk_space,
+        envs=envs,
     )
 
     if not hotplug(

--- a/tests/test_instance_envs_persistence.py
+++ b/tests/test_instance_envs_persistence.py
@@ -1,0 +1,115 @@
+"""Tests for persisting an instance's launch env vars in ``local_instances``.
+
+Covers the additive column migration (:func:`src.database.migrate.ensure_columns`)
+and the Configuration->JSON serializer used at launch
+(:func:`src.gateway.launcher.local_execution.local_execution._serialize_envs`).
+
+Follows the repo convention of guarding imports so the suite skips cleanly when the
+runtime dependencies (mnemonic, bee_rpc, protos, netifaces, a loadable config) are
+absent, and running fully in CI where they are present.
+"""
+
+import sqlite3
+import unittest
+
+MIGRATE_IMPORT_ERROR = None
+try:
+    from src.database.migrate import ensure_columns
+except Exception as exc:  # pragma: no cover - environment-dependent
+    MIGRATE_IMPORT_ERROR = exc
+    ensure_columns = None  # type: ignore[assignment]
+
+SERIALIZE_IMPORT_ERROR = None
+try:
+    from protos import celaut_pb2
+    from src.gateway.launcher.local_execution.local_execution import _serialize_envs
+except Exception as exc:  # pragma: no cover - environment-dependent
+    SERIALIZE_IMPORT_ERROR = exc
+    _serialize_envs = None  # type: ignore[assignment]
+    celaut_pb2 = None  # type: ignore[assignment]
+
+
+# The pre-migration shape of local_instances (no envs column), used to prove the
+# additive migration back-fills an existing database.
+_OLD_LOCAL_INSTANCES = """
+    CREATE TABLE local_instances (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        ip TEXT,
+        father_id TEXT,
+        gas TEXT,
+        mem_limit INTEGER,
+        disk_space INTEGER,
+        serialized_instance TEXT,
+        service_id TEXT,
+        virtualizer TEXT DEFAULT NULL
+    )
+"""
+
+
+def _columns(cur, table):
+    cur.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in cur.fetchall()}
+
+
+@unittest.skipIf(MIGRATE_IMPORT_ERROR is not None, f"Missing deps: {MIGRATE_IMPORT_ERROR}")
+class EnsureColumnsTests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(":memory:")
+        self.cur = self.conn.cursor()
+        self.cur.execute(_OLD_LOCAL_INSTANCES)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_adds_missing_column_to_existing_table(self):
+        self.assertNotIn("envs", _columns(self.cur, "local_instances"))
+        ensure_columns(self.cur, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+        self.assertIn("envs", _columns(self.cur, "local_instances"))
+
+    def test_is_idempotent(self):
+        ensure_columns(self.cur, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+        # Second run must not raise or duplicate the column.
+        ensure_columns(self.cur, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+        cols = [c for c in _columns(self.cur, "local_instances")]
+        self.assertEqual(cols.count("envs"), 1)
+
+    def test_backfilled_column_round_trips_json(self):
+        ensure_columns(self.cur, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+        self.cur.execute(
+            "INSERT INTO local_instances (id, name, envs) VALUES (?, ?, ?)",
+            ("cid", "nm", '{"SOURCE_SIGNER_MODE": "seed"}'),
+        )
+        self.cur.execute("SELECT envs FROM local_instances WHERE id = ?", ("cid",))
+        self.assertEqual(self.cur.fetchone()[0], '{"SOURCE_SIGNER_MODE": "seed"}')
+
+    def test_existing_rows_get_null_envs(self):
+        self.cur.execute(
+            "INSERT INTO local_instances (id, name) VALUES (?, ?)", ("old", "oldname")
+        )
+        ensure_columns(self.cur, "local_instances", {"envs": "TEXT DEFAULT NULL"})
+        self.cur.execute("SELECT envs FROM local_instances WHERE id = ?", ("old",))
+        self.assertIsNone(self.cur.fetchone()[0])
+
+
+@unittest.skipIf(SERIALIZE_IMPORT_ERROR is not None, f"Missing deps: {SERIALIZE_IMPORT_ERROR}")
+class SerializeEnvsTests(unittest.TestCase):
+    def test_none_config_returns_none(self):
+        self.assertIsNone(_serialize_envs(None))
+
+    def test_empty_env_map_returns_none(self):
+        self.assertIsNone(_serialize_envs(celaut_pb2.Configuration()))
+
+    def test_serializes_env_map_sorted_json(self):
+        cfg = celaut_pb2.Configuration()
+        cfg.environment_variables["SOURCE_SIGNER_MODE"] = b"seed"
+        cfg.environment_variables["SOURCE_MNEMONIC"] = b"word word word"
+        out = _serialize_envs(cfg)
+        # sort_keys keeps output deterministic regardless of insertion order.
+        self.assertEqual(
+            out, '{"SOURCE_MNEMONIC": "word word word", "SOURCE_SIGNER_MODE": "seed"}'
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
So the node can tell **how a running instance was configured** — in particular, whether a `source-application` instance was launched as a **seed signer** (`SOURCE_SIGNER_MODE=seed`) and with which seed. Today that information is lost the moment the instance starts, so the publisher's AUTO_PUBLISH_TX path (celaut-project/nodo#122) can't tell a seed-mode instance from an unsigned one and has to guess. This records the launch env so that decision can be made from fact.

## What
- **`migrate.py`** — add an `envs TEXT` column to `local_instances` (fresh DBs) and an idempotent `ensure_columns()` helper that `ALTER`s existing DBs to back-fill new columns. (`CREATE TABLE IF NOT EXISTS` never alters an existing table, so additive columns need this.)
- **`sql_connection.py`** — `add_local_instance` takes an optional `envs` (JSON text) and stores it; new `get_local_instance_envs(id)` reads it back.
- **`manager.provision_vmachine`** — threads `envs` through to `add_local_instance`.
- **`local_execution.py`** — `_serialize_envs()` turns the **sanitized** `Configuration.environment_variables` map into deterministic JSON at launch (the internal instance-name env is already stripped by `extract_instance_name`), passed into `provision_vmachine`.

## Compatibility
`envs` is an optional trailing arg and the column is nullable, so existing callers (e.g. `ggconf`) and pre-migration rows keep working with `NULL` envs.

## ⚠️ Security note
When a source-application is launched in seed mode, the stored envs include `SOURCE_MNEMONIC` in plaintext. That's the **same trust boundary** as the node's `config.yaml` (which already holds `WALLET_MNEMONIC` in plaintext). If we'd rather not persist it, a follow-up can redact/fingerprint sensitive keys before storing — easy to add.

## Tests
`tests/test_instance_envs_persistence.py`: additive-migration idempotency, existing-row back-fill, JSON round-trip, and the env serializer (`None`/empty/sorted-JSON). Guarded-import pattern (runs in CI; skips where `mnemonic`/`bee_rpc`/`protos` are absent). The pure SQL + serializer logic was also verified standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)