### PR TITLE
fix(ch): mount cgroup2 in guest initramfs for container-runtime services

### DIFF
--- a/bash/build_ch_initramfs.sh
+++ b/bash/build_ch_initramfs.sh
@@ -382,6 +382,17 @@ mount --move /sys /newroot/sys || fatal "cannot move /sys to new root"
 mount --move /dev /newroot/dev || fatal "cannot move /dev to new root"
 mount -t tmpfs -o mode=755,nosuid,nodev tmpfs /newroot/run || fatal "cannot mount /run"
 
+# Mount the unified cgroup-v2 hierarchy. The guest has no init system (the service
+# entrypoint runs as PID 1 straight out of switch_root), so nothing else mounts it.
+# Container-runtime services (e.g. a service that boots its own dockerd) need it:
+# without a cgroup mount, rootful dockerd defaults to legacy cgroup-v1, finds no
+# controllers, and aborts with "Devices cgroup isn't mounted" -> PID 1 exits ->
+# kernel panic. On v2 device control is eBPF, so no per-controller mounts are
+# needed. Non-fatal: services that don't use cgroups are unaffected if it's absent.
+mkdir -p /newroot/sys/fs/cgroup
+mount -t cgroup2 none /newroot/sys/fs/cgroup \
+    || log "warning: could not mount cgroup2 at /sys/fs/cgroup (container-runtime services may fail)"
+
 [ -f /newroot/__config__ ] || fatal "missing /__config__ in service rootfs"
 [ -f /newroot/.__nodo_entrypoint ] || fatal "missing /.__nodo_entrypoint metadata file"
 

--- a/tests/test_ch_initramfs_builder.py
+++ b/tests/test_ch_initramfs_builder.py
@@ -30,6 +30,19 @@ class CloudHypervisorInitramfsBuilderTests(unittest.TestCase):
             content.index('|| fail "modprobe returned missing module path'),
         )
 
+    def test_builder_mounts_cgroup2_after_sys_move(self):
+        # The guest has no init system (the entrypoint is PID 1 out of switch_root),
+        # so the initramfs must mount the unified cgroup-v2 hierarchy itself; otherwise
+        # container-runtime services (rootful dockerd) abort with "Devices cgroup isn't
+        # mounted" and the guest kernel panics. Must come AFTER /sys is moved to newroot
+        # (the cgroup fs lives under /newroot/sys/fs/cgroup).
+        content = Path("bash/build_ch_initramfs.sh").read_text(encoding="utf-8")
+        self.assertIn("mount -t cgroup2 none /newroot/sys/fs/cgroup", content)
+        self.assertLess(
+            content.index('mount --move /sys /newroot/sys'),
+            content.index("mount -t cgroup2 none /newroot/sys/fs/cgroup"),
+        )
+
     def test_setup_scripts_pass_guest_kernel_path_to_initramfs_builder(self):
         for script in ("bash/setup_ubuntu_x86.sh", "bash/setup_ubuntu_arm.sh"):
             with self.subTest(script=script):


### PR DESCRIPTION
## Problem

The Cloud Hypervisor guest has no init system — the service entrypoint runs as **PID 1** straight out of `switch_root`. The initramfs (`bash/build_ch_initramfs.sh` → `/init`) mounts `/proc /sys /dev /dev/shm /run` but **never the cgroup hierarchy**, and nothing else does (no systemd).

A service that boots its own `dockerd` inside the guest (Docker-in-microVM — e.g. the packer service) therefore hits:
```
failed to start daemon: Devices cgroup isn't mounted
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```
dockerd probes `/sys/fs/cgroup`, finds no cgroup2 magic, falls back to legacy cgroup-v1, finds no controller mounts, aborts → PID 1 exits → panic.

## Fix

Mount the unified **cgroup-v2** hierarchy in `/init`, right after `/sys` is moved to newroot. On v2, device control is eBPF, so no per-controller mounts are needed. **Non-fatal** so services that don't use cgroups are unaffected if it's absent.

This is the substrate-level fix — container-runtime services previously had to mount cgroup2 in their own entrypoint; a guarded self-mount stays a harmless no-op once this lands.

## Verification

- Confirmed live on an Alienware nodo: with the guest mounting cgroup2, the packer microVM boots past the panic — serial log goes `cgroup2 mounted → dockerd ready → listening on 0.0.0.0:8080`, and `:8080` serves **HTTP 200**.
- `bash -n` clean; initramfs builder tests **4/4 pass** (adds a regression test asserting the cgroup2 mount follows the `/sys` move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)