### PR TITLE
fix(ch-initramfs): don't false-fail when a virtio module is built into the guest kernel

### DIFF
--- a/bash/build_ch_initramfs.sh
+++ b/bash/build_ch_initramfs.sh
@@ -473,10 +473,19 @@ if command -v lsinitramfs >/dev/null 2>&1; then
     printf '%s\n' "$listing" | grep -qx 'bin/busybox' || fail "generated initramfs misses /bin/busybox"
     printf '%s\n' "$listing" | grep -qx 'etc/nodo-ch-initramfs.marker' || fail "generated initramfs misses marker"
     if printf '%s\n' "$listing" | grep -qx 'etc/nodo-virtio-modules.list'; then
-        printf '%s\n' "$listing" | grep -Eq '(^|/)virtio_blk\.ko$' \
-            || fail "generated initramfs has module list but misses virtio_blk.ko"
-        printf '%s\n' "$listing" | grep -Eq '(^|/)virtio_net\.ko$' \
-            || fail "generated initramfs has module list but misses virtio_net.ko"
+        # Validate that every module actually recorded in the list is packed into
+        # the initramfs. Do NOT hard-require both virtio_blk and virtio_net: a guest
+        # kernel may have one built in (=y, no .ko emitted) and the other as a
+        # loadable module (=m). install_virtio_modules only records the loadable
+        # ones and skips built-ins, so the list is the source of truth. Hard-coding
+        # both names false-failed the build when a virtio_blk=y / virtio_net=m guest
+        # kernel emitted only virtio_net.ko into the list.
+        while IFS= read -r module_path; do
+            [ -n "$module_path" ] || continue
+            module_rel="${module_path#/}"
+            printf '%s\n' "$listing" | grep -qx "$module_rel" \
+                || fail "generated initramfs is missing listed module: $module_rel"
+        done < "$ROOT/etc/nodo-virtio-modules.list"
     fi
 fi
 

--- a/tests/test_ch_initramfs_builder.py
+++ b/tests/test_ch_initramfs_builder.py
@@ -43,6 +43,19 @@ class CloudHypervisorInitramfsBuilderTests(unittest.TestCase):
             content.index("mount -t cgroup2 none /newroot/sys/fs/cgroup"),
         )
 
+    def test_validator_tolerates_builtin_virtio_module(self):
+        # A guest kernel may ship virtio_blk built in (=y, no .ko) and virtio_net as
+        # a loadable module (=m), or vice-versa. install_virtio_modules skips the
+        # built-in ones, so the module list may legitimately contain only one of the
+        # two. The final validator must check the modules actually recorded in the
+        # list, not hard-require both virtio_blk.ko and virtio_net.ko — the old
+        # behavior false-failed with "misses virtio_blk.ko" on such kernels.
+        content = Path("bash/build_ch_initramfs.sh").read_text(encoding="utf-8")
+        self.assertNotIn("has module list but misses virtio_blk.ko", content)
+        self.assertNotIn("has module list but misses virtio_net.ko", content)
+        self.assertIn('done < "$ROOT/etc/nodo-virtio-modules.list"', content)
+        self.assertIn("generated initramfs is missing listed module", content)
+
     def test_setup_scripts_pass_guest_kernel_path_to_initramfs_builder(self):
         for script in ("bash/setup_ubuntu_x86.sh", "bash/setup_ubuntu_arm.sh"):
             with self.subTest(script=script):


### PR DESCRIPTION
## Problem

Josemi hit this during `celaut-project/nodo` install:

```
generated initramfs has module list but misses virtio_blk.ko
```

This is **not** a missing-driver problem — it's a false failure in the post-build validator.

## Root cause

`install_virtio_modules` correctly **skips** any virtio module that is built into the guest kernel (`=y`, listed in `modules.builtin`) and only records the **loadable** (`=m`) ones into `etc/nodo-virtio-modules.list`.

But the final validator (`build_ch_initramfs.sh`, tail) hard-required **both** `virtio_blk.ko` **and** `virtio_net.ko` to be present whenever a module list existed. So a guest kernel with:

- `CONFIG_VIRTIO_BLK=y` (built-in → no `.ko`, correctly skipped), and
- `CONFIG_VIRTIO_NET=m` (module → `virtio_net.ko` packed, list non-empty)

produces a **valid** initramfs that would boot fine (built-in `virtio_blk` gives `/dev/vda` with no `insmod`), yet the validator aborted with `misses virtio_blk.ko`.

## Why we still need virtio_blk / virtio_net (re: "¿necesitamos virtio_blk y virtio_net si usamos virtiofs?")

virtiofs is **not** the guest rootfs here. `init` mounts the service rootfs from `/dev/vda` (`mount -t ext4 /dev/vda /newroot`), so `virtio_blk` is mandatory; `virtio_net` backs the `ip=` guest-network bootstrap. virtiofs is the separate "shared-disk networks" feature exported by `virtiofsd` — it never replaces the block-based root. So dropping the drivers isn't the fix; the validator is.

## Fix

Validate that **every module actually recorded in the list** is present in the initramfs, instead of hard-coding both driver names. The list is the source of truth for which modules were loadable and needed packing. A genuinely missing module still hard-fails, with a precise message.

## Testing

- `bash -n` parses clean.
- `python3 -m unittest tests.test_ch_initramfs_builder` — 3/3 pass (adds `test_validator_tolerates_builtin_virtio_module`).
- Simulated the validator against a mixed builtin/module listing (only `virtio_net.ko` present) → **passes**; and against a list referencing an absent `.ko` → **correctly fails**.

## Unblock for Josemi right now

Either merge this, or use a guest kernel with **both** `CONFIG_VIRTIO_BLK=y` and `CONFIG_VIRTIO_NET=y` built in (list ends up empty, validator block is skipped entirely).
