### PR TITLE
feat(ch): add overlay module to guest initramfs for overlay2

### DIFF
--- a/bash/build_ch_initramfs.sh
+++ b/bash/build_ch_initramfs.sh
@@ -148,7 +148,10 @@ install_virtio_modules() {
     # virtiofs (+ its fuse dependency, pulled in by --show-depends) is needed for
     # parent -> child shared filesystems. Harmless when unused: it is only loaded,
     # never auto-mounted.
-    for required_module in virtio_blk virtio_net virtiofs; do
+    # overlay is needed so a service that boots its own Docker daemon inside the
+    # guest can use the overlay2 storage driver. Without it dockerd falls back to
+    # vfs (full-copy layers), which makes an image build take ~150s instead of ~8s.
+    for required_module in virtio_blk virtio_net virtiofs overlay; do
         deps="$(modprobe --set-version "$kernel_release" --show-depends "$required_module" 2>/dev/null || true)"
         if [ -z "$deps" ]; then
             if is_builtin_module "$kernel_release" "$required_module"; then


### PR DESCRIPTION
## Módulo overlay añadido al initramfs del kernel-invitado CH

Añade el módulo `overlay` al initramfs del kernel-invitado de Cloud Hypervisor (reconstruido para `5.15.0-185-generic`). Ahora el Docker interno usa **overlay2** y el packer levanta en **~8 s en vez de ~150 s**.

### Why

A service that boots its own Docker daemon inside a CH microVM (the `packer-service` runs `dockerd` + `buildx` to build images) needs an overlay-capable guest kernel. Today the guest kernel/initramfs ships only `virtio_blk`, `virtio_net`, and `virtiofs`, so in-VM `dockerd` fails to mount overlay:

```
failed to mount overlay: no such device
```

and falls back to the **`vfs`** storage driver. `vfs` full-copies every image layer, so the packer takes ~150 s to become serviceable — long enough that nodo's endpoint-readiness check gives up and tears the microVM down before `:8080` is reachable (surfacing as *"No endpoints available"*).

### Fix

Add `overlay` to the list of modules pulled into the guest initramfs in `install_virtio_modules()`. Modules in this list are loaded at guest boot (same path as `virtiofs`), so `overlay.ko` is present and `dockerd` can use `overlay2`. The packer then boots in **~8 s**.

One-line change (plus an explanatory comment). No effect on services that don't run a nested container runtime — the module is only loaded, never auto-mounted.

### Testing

Rebuilt the CH guest initramfs for `5.15.0-185-generic` on an Ubuntu 22.04 (WSL2, `/dev/kvm`) host and re-ran a packer-service microVM: in-guest `dockerd` came up on `overlay2` and the packer became serviceable in ~8 s instead of ~150 s.
