### PR TITLE
docs, tests: reconcile with packer/core-services refactor (0a5711e)

### DIFF
--- a/docs/design/low-demand-fallback.md
+++ b/docs/design/low-demand-fallback.md
@@ -95,7 +95,7 @@ is concrete rather than hand-wavy.
 
 - `src/core_services/runtime.py` —
   `ensure_core_service_running(service_id, *, launch=True)`
-  resolves an already-running instance (`find_running_endpoint`), else
+  resolves an already-running instance (`_find_running_endpoint`), else
   best-effort downloads via the source-application, else launches via the
   canonical `nodo execute` path (`src/commands/execute.py:116`). Fully
   defensive, never raises. **The fallback launches through exactly this.**
@@ -108,10 +108,10 @@ is concrete rather than hand-wavy.
 - Gateway exposes it: `Gateway.StopService` at `src/gateway/gateway.py:31` calls
   `stop_instance(token=token)`.
 
-  To stop the fallback we need its **token/instance id**. `find_running_endpoint`
-  (runtime.py) currently returns only the endpoint; to preempt we also need the
+  To stop the fallback we need its **token/instance id**. `_find_running_endpoint`
+  (runtime.py) returns only the endpoint; to preempt we also need the
   instance token so we can call `stop_instance`. **(open question 2 — we propose
-  adding a small `find_running_instance(service_id) -> (token, endpoint)` helper,
+  adding a small `find_running_instance(service_id) -> token` helper,
   or having the scheduler track the token it launched.)**
 
 ### 2.5 The preemption trigger (a real request arriving)
@@ -223,8 +223,8 @@ The three design questions below were put to maintainer Josemi and are now
    Celaut today. When a real `execute` request arrives, or resources exceed a
    threshold, the low-demand instance is **stopped immediately** via
    `stop_instance()` (`manager.py:531`) — never paused/suspended. To get the
-   instance's stop token we added `find_running_instance(service_id) -> (token,
-   endpoint)` to `runtime.py`, and the scheduler also remembers the token it
+   instance's stop token we added `find_running_instance(service_id) -> token`
+   to `runtime.py`, and the scheduler also remembers the token it
    launched. Implemented in `_stop_running_fallback()`.
 
 3. **Request detection — FINAL: POLLED, not reactive.** Pending/running real
@@ -261,8 +261,8 @@ The three design questions below were put to maintainer Josemi and are now
   fallback's own instance), `should_run_fallback()`, `run_fallback_once()`, and the
   stateful `scheduler_tick()` (hysteresis + always-stop preemption + `POLL_INTERVAL`
   cadence). Heavily documented, never raises.
-- `src/core_services/runtime.py` — `find_running_instance(service_id) -> (token,
-  endpoint)` so preemption can `stop_instance()` the fallback.
+- `src/core_services/runtime.py` — `find_running_instance(service_id) -> token`
+  so preemption can `stop_instance()` the fallback.
 - `src/manager/maintain.py` — a single guarded `scheduler_tick()` call wired into
   the existing `manager_thread` loop (no new thread; no-op unless `ENABLED`).
 - `tests/test_low_demand.py` — unit tests with mocked resource readings, a mocked

--- a/src/commands/packer/zip_with_dockerfile/pack.py
+++ b/src/commands/packer/zip_with_dockerfile/pack.py
@@ -149,7 +149,7 @@ def _resolve_packer_endpoint() -> Optional[str]:
         if endpoint:
             return endpoint
         
-    if PACKER_SERVICE_URL.strip():
+    if PACKER_SERVICE_URL and PACKER_SERVICE_URL.strip():
         print(
             f"Could not start packer service id {service_id}; "
             "falling back to PACKER_SERVICE_URL if set."

--- a/tests/test_core_services_runtime.py
+++ b/tests/test_core_services_runtime.py
@@ -50,7 +50,7 @@ class _FakeConn:
 
 
 def _patch_db(rows=None, raise_on_execute=None, raise_on_connect=None):
-    """Patch sqlite3.connect + DATABASE_FILE config used by runtime.find_running_endpoint."""
+    """Patch sqlite3.connect + DATABASE_FILE config used by runtime._find_running_endpoint."""
     cursor = _FakeCursor(rows=rows, raise_on_execute=raise_on_execute)
 
     def fake_connect(_path):
@@ -139,7 +139,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
         acquire = MagicMock(return_value=True)
         launch = MagicMock()
         with patch.object(
-            runtime, "find_running_endpoint", return_value="http://127.0.0.1:18080"
+            runtime, "_find_running_endpoint", return_value="http://127.0.0.1:18080"
         ) as find, _stub_deps(acquire, launch):
             result = runtime.ensure_core_service_running("svc")
 
@@ -152,21 +152,21 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
         acquire = MagicMock(return_value=False)
         launch = MagicMock()
         with patch.object(
-            runtime, "find_running_endpoint", return_value=None
+            runtime, "_find_running_endpoint", return_value=None
         ) as find, _stub_deps(acquire, launch):
             result = runtime.ensure_core_service_running("svc", launch=False)
 
         self.assertIsNone(result)
         acquire.assert_called_once_with("svc")
         launch.assert_not_called()
-        # find_running_endpoint called at the top and again at the bottom.
+        # _find_running_endpoint called at the top and again at the bottom.
         self.assertEqual(find.call_count, 2)
 
     def test_acquire_true_but_still_no_instance_returns_none(self):
         acquire = MagicMock(return_value=True)
         launch = MagicMock()
         with patch.object(
-            runtime, "find_running_endpoint", return_value=None
+            runtime, "_find_running_endpoint", return_value=None
         ), _stub_deps(acquire, launch):
             result = runtime.ensure_core_service_running("svc")
 
@@ -178,7 +178,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
         acquire = MagicMock(return_value=False)
         launch = MagicMock(side_effect=RuntimeError("no gateway"))
         with patch.object(
-            runtime, "find_running_endpoint", return_value=None
+            runtime, "_find_running_endpoint", return_value=None
         ), _stub_deps(acquire, launch):
             # Must not raise even though execute() blows up.
             result = runtime.ensure_core_service_running("svc")
@@ -192,7 +192,7 @@ class EnsureCoreServiceRunningTests(unittest.TestCase):
         launch = MagicMock()
         with patch.object(
             runtime,
-            "find_running_endpoint",
+            "_find_running_endpoint",
             side_effect=[None, "http://10.0.0.9:7000"],
         ), _stub_deps(acquire, launch):
             result = runtime.ensure_core_service_running("svc")

--- a/tests/test_packer_endpoint_resolution.py
+++ b/tests/test_packer_endpoint_resolution.py
@@ -1,14 +1,16 @@
 """Unit tests for `nodo pack` packer-endpoint resolution.
 
-Covers `_resolve_packer_endpoint_by_id` (sqlite + protobuf lookup of a running
-packer-service instance) and the `pack()` resolution order: service id first
-(running instance), then the PACKER_SERVICE_URL override, then an actionable
-failure message. No real packing or network I/O happens here.
+Covers the `_resolve_packer_endpoint()` resolution order — packer **service id**
+first (launched/resolved on demand through the core-services runtime), then the
+`PACKER_SERVICE_URL` override, then an actionable failure message — and the
+`_wait_for_packer_health` poll loop. No real packing or network I/O happens here.
+
+Note: running-instance lookup + on-demand launch now live entirely in
+`src.core_services.runtime.ensure_core_service_running` (exercised by
+`test_core_services_runtime.py`); `pack.py` just calls it, so these tests mock it.
 """
 import io
 import os
-import sqlite3
-import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest import mock
@@ -16,117 +18,53 @@ from unittest.mock import patch
 
 IMPORT_ERROR = None
 try:
-    from protos import celaut_pb2 as celaut
     from src.commands.packer.zip_with_dockerfile import pack as pack_mod
 except Exception as import_exc:  # pragma: no cover - environment-dependent
     IMPORT_ERROR = import_exc
-    celaut = None  # type: ignore[assignment]
     pack_mod = None  # type: ignore[assignment]
-
-
-def _serialized_instance(ip: str = "10.0.0.7", port: int = 8080) -> bytes:
-    instance = celaut.Instance()
-    slot = celaut.Instance.Uri_Slot()
-    slot.internal_port = port
-    slot.uri.append(celaut.Instance.Uri(ip=ip, port=port))
-    instance.uri_slot.append(slot)
-    return instance.SerializeToString()
-
-
-@unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
-class ResolvePackerEndpointByIdTests(unittest.TestCase):
-    def _build_db(self, db_path: str, service_id: str, serialized: bytes) -> None:
-        conn = sqlite3.connect(db_path)
-        try:
-            conn.execute(
-                "CREATE TABLE local_instances (id TEXT PRIMARY KEY, service_id TEXT, serialized_instance BLOB)"
-            )
-            conn.execute(
-                "INSERT INTO local_instances (id, service_id, serialized_instance) VALUES (?, ?, ?)",
-                ("inst-1", service_id, serialized),
-            )
-            conn.commit()
-        finally:
-            conn.close()
-
-    def test_id_resolves_to_running_instance_endpoint(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            db_path = os.path.join(tmp, "node.db")
-            self._build_db(db_path, "packerid123", _serialized_instance("10.0.0.7", 8080))
-            with patch.object(pack_mod.env_manager, "get", return_value=db_path):
-                endpoint = pack_mod._resolve_packer_endpoint_by_id("packerid123")
-            self.assertEqual(endpoint, "http://10.0.0.7:8080")
-
-    def test_no_matching_row_returns_none(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            db_path = os.path.join(tmp, "node.db")
-            self._build_db(db_path, "someotherid", _serialized_instance())
-            with patch.object(pack_mod.env_manager, "get", return_value=db_path):
-                endpoint = pack_mod._resolve_packer_endpoint_by_id("packerid123")
-            self.assertIsNone(endpoint)
-
-    def test_missing_table_returns_none(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            db_path = os.path.join(tmp, "node.db")
-            sqlite3.connect(db_path).close()  # empty DB, no local_instances table
-            with patch.object(pack_mod.env_manager, "get", return_value=db_path):
-                endpoint = pack_mod._resolve_packer_endpoint_by_id("packerid123")
-            self.assertIsNone(endpoint)
-
-    def test_unparseable_blob_returns_none(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            db_path = os.path.join(tmp, "node.db")
-            self._build_db(db_path, "packerid123", b"\xff\xfe not a protobuf")
-            with patch.object(pack_mod.env_manager, "get", return_value=db_path):
-                endpoint = pack_mod._resolve_packer_endpoint_by_id("packerid123")
-            self.assertIsNone(endpoint)
-
-    def test_empty_service_id_returns_none(self):
-        self.assertIsNone(pack_mod._resolve_packer_endpoint_by_id(""))
 
 
 @unittest.skipIf(IMPORT_ERROR is not None, f"Missing runtime dependencies: {IMPORT_ERROR}")
 class PackResolutionOrderTests(unittest.TestCase):
-    def test_id_set_and_instance_running_uses_instance_endpoint(self):
+    def test_id_set_and_core_service_running_uses_that_endpoint(self):
+        # A configured id resolves/launches via the core-services runtime; that
+        # endpoint wins and the URL override is NOT consulted.
         with patch.object(pack_mod, "_resolve_packer_id", return_value="packerid123"), \
-             patch.object(pack_mod, "_resolve_packer_endpoint_by_id", return_value="http://10.0.0.7:8080") as by_id, \
-             patch.object(pack_mod, "_resolve_packer_url", return_value="http://override:8080") as by_url:
-            endpoint = pack_mod._resolve_packer_endpoint()
-        self.assertEqual(endpoint, "http://10.0.0.7:8080")
-        by_id.assert_called_once_with("packerid123")
-        by_url.assert_not_called()
-
-    def test_id_set_no_instance_launches_packer_via_core_services(self):
-        # No running instance, but the core-services runtime downloads+launches the
-        # packer and yields a live endpoint — that endpoint is used and the URL
-        # override is NOT consulted.
-        with patch.object(pack_mod, "_resolve_packer_id", return_value="packerid123"), \
-             patch.object(pack_mod, "_resolve_packer_endpoint_by_id", return_value=None), \
-             patch.object(pack_mod, "_ensure_packer_running", return_value="http://10.0.0.9:8080") as ensure, \
-             patch.object(pack_mod, "_resolve_packer_url", return_value="http://override:8080") as by_url:
+             patch.object(pack_mod, "ensure_core_service_running", return_value="http://10.0.0.9:8080") as ensure, \
+             patch.object(pack_mod, "PACKER_SERVICE_URL", "http://override:8080"):
             endpoint = pack_mod._resolve_packer_endpoint()
         self.assertEqual(endpoint, "http://10.0.0.9:8080")
         ensure.assert_called_once_with("packerid123")
-        by_url.assert_not_called()
 
-    def test_id_set_no_instance_and_launch_fails_falls_back_to_url_override(self):
+    def test_id_set_launch_fails_falls_back_to_url_override(self):
+        # id configured but the runtime can neither find nor launch an instance →
+        # fall back to the out-of-band PACKER_SERVICE_URL override.
         out = io.StringIO()
         with patch.object(pack_mod, "_resolve_packer_id", return_value="packerid123"), \
-             patch.object(pack_mod, "_resolve_packer_endpoint_by_id", return_value=None), \
-             patch.object(pack_mod, "_ensure_packer_running", return_value=None), \
-             patch.object(pack_mod, "_resolve_packer_url", return_value="http://override:8080"):
+             patch.object(pack_mod, "ensure_core_service_running", return_value=None), \
+             patch.object(pack_mod, "PACKER_SERVICE_URL", "http://override:8080"):
             with redirect_stdout(out):
                 endpoint = pack_mod._resolve_packer_endpoint()
         self.assertEqual(endpoint, "http://override:8080")
         self.assertIn("packerid123", out.getvalue())
 
+    def test_id_set_launch_fails_no_url_returns_none(self):
+        # id configured, launch fails, and no URL override (PACKER_SERVICE_URL is
+        # unset -> None): resolve to None without raising (regression guard for the
+        # `None.strip()` path).
+        with patch.object(pack_mod, "_resolve_packer_id", return_value="packerid123"), \
+             patch.object(pack_mod, "ensure_core_service_running", return_value=None), \
+             patch.object(pack_mod, "PACKER_SERVICE_URL", None):
+            self.assertIsNone(pack_mod._resolve_packer_endpoint())
+
     def test_no_id_uses_url_override(self):
+        # No packer id at all: the runtime is never called; the URL override is used.
         with patch.object(pack_mod, "_resolve_packer_id", return_value=None), \
-             patch.object(pack_mod, "_resolve_packer_endpoint_by_id") as by_id, \
-             patch.object(pack_mod, "_resolve_packer_url", return_value="http://override:8080"):
+             patch.object(pack_mod, "ensure_core_service_running") as ensure, \
+             patch.object(pack_mod, "PACKER_SERVICE_URL", "http://override:8080"):
             endpoint = pack_mod._resolve_packer_endpoint()
         self.assertEqual(endpoint, "http://override:8080")
-        by_id.assert_not_called()
+        ensure.assert_not_called()
 
     def test_id_resolves_from_core_services_list(self):
         # With no env var and no packer.PACKER_SERVICE_ID, the id is taken from a
@@ -138,6 +76,7 @@ class PackResolutionOrderTests(unittest.TestCase):
                 return [{"name": "packer", "id": "coreid789"}]
             return default
         with patch.dict(os.environ, {}, clear=True), \
+             patch.object(pack_mod, "PACKER_SERVICE_ID", None), \
              patch.object(pack_mod.env_manager, "get", side_effect=fake_get), \
              patch("src.core_services._env_manager.get", side_effect=fake_get):
             self.assertEqual(pack_mod._resolve_packer_id(), "coreid789")
@@ -145,7 +84,7 @@ class PackResolutionOrderTests(unittest.TestCase):
     def test_neither_set_returns_none_and_pack_prints_guidance(self):
         out = io.StringIO()
         with patch.object(pack_mod, "_resolve_packer_id", return_value=None), \
-             patch.object(pack_mod, "_resolve_packer_url", return_value=None):
+             patch.object(pack_mod, "PACKER_SERVICE_URL", None):
             self.assertIsNone(pack_mod._resolve_packer_endpoint())
             # pack() should short-circuit with the no-packer message and never
             # touch prepare_directory / requests.


### PR DESCRIPTION
Follow-up to **0a5711e** ("multiple refactor on claude code") — brings `docs/` and `tests/` in line with the changed API surface. All affected tests pass (`46 passed`); full suite unchanged (127 passed / 122 skipped locally; the 5 `bee_rpc` collection errors are pre-existing/env-only).

### tests
- **`test_packer_endpoint_resolution.py`** — the helpers it covered (`_resolve_packer_endpoint_by_id`, `_resolve_packer_url`, `_ensure_packer_running`) were removed; running-instance lookup + on-demand launch now live in `runtime.ensure_core_service_running`. Rewrote the resolution-order tests against the new flow (mock `ensure_core_service_running` + the `PACKER_SERVICE_URL` module constant). Kept the `_wait_for_packer_health` poll tests unchanged.
- **`test_core_services_runtime.py`** — `find_running_endpoint` → private `_find_running_endpoint`. The `FindRunningEndpoint` class was already updated in 0a5711e, but the 5 `EnsureCoreServiceRunning` tests still patched the public name and would `AttributeError`. Fixed.

### docs
- **`design/low-demand-fallback.md`** — `_find_running_endpoint` (now private) and `find_running_instance(service_id) -> token` (return type no longer carries the endpoint).

### one-line regression guard (src)
- **`pack.py` `_resolve_packer_endpoint`** — `PACKER_SERVICE_URL.strip()` now guards for `None`. The refactor dropped the `or ""` default on `PACKER_SERVICE_URL = env_manager.get("PACKER_SERVICE_URL")`, and `ConfigManager.get` returns `None` for an unset key. So on the common path (no URL override, packer can't launch), `nodo pack` hit `None.strip()` → `AttributeError` instead of printing the "No packer service is configured" guidance. New test `test_id_set_launch_fails_no_url_returns_none` covers it. Happy to drop this hunk if you'd rather restore the default at the assignment instead.